### PR TITLE
Add local docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.3"
 
 services:
   onboard:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.8"
+
+services:
+  onboard:
+    image: dukerobotics/robosub-ros:onboard
+    container_name: onboard
+    privileged: true
+    ports: 
+      - 2200:2200
+    networks:
+      local_net:
+        ipv4_address: 192.168.1.1
+    tty: true
+    volumes:
+      - type: bind
+        source: .
+        target: /root/dev/robosub-ros
+
+  landside:
+    image: dukerobotics/robosub-ros:landside
+    container_name: landside
+    privileged: true
+    ports:
+      - 2201:2201
+      - 8080:8080
+    networks:
+      local_net:
+        ipv4_address: 192.168.1.2
+    tty: true
+    volumes:
+      - type: bind
+        source: .
+        target: /root/dev/robosub-ros
+
+ 
+networks:
+  local_net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.0.0/16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3"
 
 services:
   onboard:


### PR DESCRIPTION
Adds a docker-compose file that can start up both landside and onboard containers on the same machine. Assigns static IPs to the containers and creates a network to better reflect our actual setup.