### PR TITLE
Set 8.8.8.8 as DNS for containers in docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
       local_net:
         ipv4_address: 192.168.1.1
     tty: true
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
     volumes:
       - type: bind
         source: .
@@ -27,6 +30,9 @@ services:
       local_net:
         ipv4_address: 192.168.1.2
     tty: true
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
     volumes:
       - type: bind
         source: .


### PR DESCRIPTION
Sets 8.8.8.8 or 8.8.4.4 as the DNS for containers. Fixes issue where you can't connect to the internet from inside the container when using this docker compose file.