### PR TITLE
Resource retriever

### DIFF
--- a/landside/catkin_ws/src/camera_view/CMakeLists.txt
+++ b/landside/catkin_ws/src/camera_view/CMakeLists.txt
@@ -10,8 +10,9 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   std_msgs
   cv_bridge
+  resource_retriever
 )
 
 ## The catkin_package macro generates cmake config files for your package
 ## Declare things to be passed to dependent projects
-catkin_package(CATKIN_DEPENDS image_view image_publisher rosbag rospy sensor_msgs std_msgs cv_bridge)
+catkin_package(CATKIN_DEPENDS image_view image_publisher rosbag rospy sensor_msgs std_msgs cv_bridge resource_retriever)

--- a/landside/catkin_ws/src/camera_view/package.xml
+++ b/landside/catkin_ws/src/camera_view/package.xml
@@ -17,6 +17,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>cv_bridge</depend>
+  <depend>resource_retriever</depend>
 
   <exec_depend>opencv-python</exec_depend>
 

--- a/landside/catkin_ws/src/camera_view/scripts/bag_to_video.py
+++ b/landside/catkin_ws/src/camera_view/scripts/bag_to_video.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 
-import rospy
 import rosbag
 import numpy as np
 import cv2
-from cv_bridge import CvBridge
 from converter_interface import BagVideoConverter
 from itertools import izip
 

--- a/landside/catkin_ws/src/camera_view/scripts/converter_interface.py
+++ b/landside/catkin_ws/src/camera_view/scripts/converter_interface.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python
 
-import os
-import sys
 import rospy
-import rosbag
 from cv_bridge import CvBridge
+import resource_retriever as rr
 
 
 class BagVideoConverter:
 
     def __init__(self):
         rospy.init_node("bag_video_converter", anonymous=True)
-        self.bag_file = os.path.join(sys.path[0], "../bag", rospy.get_param("~bag_file"))
-        video_file_list = [os.path.join(sys.path[0], "../avi", file) for file in rospy.get_param("~video_file")]
+        bag_res = 'package://camera_view/bag/{}'.format(rospy.get_param("~bag_file"))
+        self.bag_file = rr.get_filename(bag_res, use_protocol=False)
+        avi_res = 'package://camera_view/avi/{}'
+        vid_file_list = [rr.get_filename(avi_res.format(f), use_protocol=False) for f in rospy.get_param("~video_file")]
         self.topic_name = rospy.get_param("~topic_name")
-        self.video_files = {self.topic_name[i]: video_file_list[i] for i in range(len(self.topic_name))}
+        self.video_files = {self.topic_name[i]: vid_file_list[i] for i in range(len(self.topic_name))}
         self.bridge = CvBridge()

--- a/landside/catkin_ws/src/camera_view/scripts/video_to_bag.py
+++ b/landside/catkin_ws/src/camera_view/scripts/video_to_bag.py
@@ -2,10 +2,7 @@
 
 import rospy
 import rosbag
-import numpy as np
 import cv2
-from sensor_msgs.msg import Image
-from std_msgs.msg import Header
 from converter_interface import BagVideoConverter
 
 

--- a/landside/catkin_ws/src/joystick/CMakeLists.txt
+++ b/landside/catkin_ws/src/joystick/CMakeLists.txt
@@ -7,8 +7,9 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   geometry_msgs
   joy
+  resource_retriever
 )
 
 ## The catkin_package macro generates cmake config files for your package
 ## Declare things to be passed to dependent projects
-catkin_package(CATKIN_DEPENDS rospy sensor_msgs geometry_msgs joy)
+catkin_package(CATKIN_DEPENDS rospy sensor_msgs geometry_msgs joy resource_retriever)

--- a/landside/catkin_ws/src/joystick/package.xml
+++ b/landside/catkin_ws/src/joystick/package.xml
@@ -14,6 +14,7 @@
   <depend>joy</depend>
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>resource_retriever</depend>
 
   <exec_depend>python-yaml</exec_depend>
 

--- a/landside/catkin_ws/src/joystick/scripts/joystick.py
+++ b/landside/catkin_ws/src/joystick/scripts/joystick.py
@@ -2,11 +2,10 @@
 
 import rospy
 import yaml
-import sys
-import os
 from geometry_msgs.msg import Twist
 from sensor_msgs.msg import Joy
 from enum import Enum
+import resource_retriever as rr
 
 
 class Movement(Enum):
@@ -25,7 +24,7 @@ class JoystickParser:
         self._movement_type = Movement.TRANSLATION
 
         joystick_type = rospy.get_param("~/joy_pub/joystick_type")
-        with open(os.path.join(sys.path[0], '../config/joystick.yaml')) as f:
+        with open(rr.get_filename('package://joystick/config/joystick.yaml', use_protocol=False)) as f:
             data = yaml.load(f)
         self._button_indices = data[joystick_type]
 

--- a/onboard/catkin_ws/src/controls/CMakeLists.txt
+++ b/onboard/catkin_ws/src/controls/CMakeLists.txt
@@ -10,8 +10,9 @@ find_package(catkin REQUIRED COMPONENTS
   std_srvs
   tf
   pid
+  resource_retriever
 )
 
 ## The catkin_package macro generates cmake config files for your package
 ## Declare things to be passed to dependent projects
-catkin_package(CATKIN_DEPENDS rospy std_msgs nav_msgs geometry_msgs std_srvs custom_msgs tf pid)
+catkin_package(CATKIN_DEPENDS rospy std_msgs nav_msgs geometry_msgs std_srvs custom_msgs tf pid resource_retriever)

--- a/onboard/catkin_ws/src/controls/package.xml
+++ b/onboard/catkin_ws/src/controls/package.xml
@@ -18,6 +18,7 @@
   <depend>std_srvs</depend>
   <depend>tf</depend>
   <depend>pid</depend>
+  <depend>resource_retriever</depend>
 
   <exec_depend>python-numpy</exec_depend>
   <exec_depend>python-yaml</exec_depend>

--- a/onboard/catkin_ws/src/controls/scripts/thruster_controls.py
+++ b/onboard/catkin_ws/src/controls/scripts/thruster_controls.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-import sys
-import os
-
 import rospy
 from std_msgs.msg import Float64, Float32MultiArray, Int8MultiArray
 from geometry_msgs.msg import Vector3Stamped
@@ -11,6 +8,7 @@ from thruster_manager import ThrusterManager
 from std_srvs.srv import SetBool
 from tf import TransformListener
 import controls_utils as utils
+import resource_retriever as rr
 
 
 class ThrusterController:
@@ -31,7 +29,7 @@ class ThrusterController:
 
         self.enable_service = rospy.Service('enable_controls', SetBool, self.handle_enable_controls)
 
-        self.tm = ThrusterManager(os.path.join(sys.path[0], '../config/cthulhu.config'))
+        self.tm = ThrusterManager(rr.get_filename('package://controls/config/cthulhu.config', use_protocol=False))
 
         self.listener = TransformListener()
 

--- a/onboard/catkin_ws/src/cv/CMakeLists.txt
+++ b/onboard/catkin_ws/src/cv/CMakeLists.txt
@@ -8,10 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
 	sensor_msgs
 	cv_bridge
 	rospy
+	resource_retriever
 )
 
 ## The catkin_package macro generates cmake config files for your package
 ## Declare things to be passed to dependent projects
-catkin_package(CATKIN_DEPENDS rospy sensor_msgs custom_msgs cv_bridge)
+catkin_package(CATKIN_DEPENDS rospy sensor_msgs custom_msgs cv_bridge resource_retriever)
 
 

--- a/onboard/catkin_ws/src/cv/package.xml
+++ b/onboard/catkin_ws/src/cv/package.xml
@@ -12,6 +12,7 @@
   <depend>sensor_msgs</depend>
   <depend>custom_msgs</depend>
   <depend>cv_bridge</depend>
+  <depend>resource_retriever</depend>
 
   <exec_depend>python-yaml</exec_depend>
   <exec_depend>python-opencv</exec_depend>

--- a/onboard/catkin_ws/src/cv/scripts/detection.py
+++ b/onboard/catkin_ws/src/cv/scripts/detection.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 import rospy
-import os
 import yaml
 from custom_msgs.msg import CVObject
 from custom_msgs.srv import EnableModel
 from sensor_msgs.msg import Image
 from cv_bridge import CvBridge
 from detecto.core import Model
+import resource_retriever as rr
 
 
 class Detector:
@@ -20,8 +20,7 @@ class Detector:
         self.camera = rospy.get_param('~camera')
 
         # Load in model configurations
-        curr_directory = os.path.dirname(__file__)
-        with open(os.path.join(curr_directory, '../models/models.yaml')) as f:
+        with open(rr.get_filename('package://cv/models/models.yaml', use_protocol=False)) as f:
             self.models = yaml.load(f)
 
         # The topic that the camera publishes its feed to
@@ -38,8 +37,7 @@ class Detector:
         if model.get('predictor') is not None:
             return
 
-        path = os.path.dirname(__file__)
-        weights_file = os.path.join(path, '../models', model['weights'])
+        weights_file = rr.get_filename('package://cv/models/{}'.format(model['weights']), use_protocol=False)
 
         predictor = Model.load(weights_file, model['classes'])
 


### PR DESCRIPTION
Use ROS resource retriever to load files into python. This provides clearer filepaths than using sys.path and os.path.join.

Also optimizes the imports in the camera view package.