### PR TITLE
Google Drive package

### DIFF
--- a/core/catkin_ws/src/custom_msgs/CMakeLists.txt
+++ b/core/catkin_ws/src/custom_msgs/CMakeLists.txt
@@ -18,6 +18,8 @@ add_service_files(
   FILES
   SetServo.srv
   EnableModel.srv
+  FileDownload.srv
+  FileUpload.srv
 )
 
 generate_messages(

--- a/core/catkin_ws/src/custom_msgs/srv/FileDownload.srv
+++ b/core/catkin_ws/src/custom_msgs/srv/FileDownload.srv
@@ -1,0 +1,7 @@
+# Google drive id of file to download
+string file_id
+
+# Package URL or local filepath to download file to
+string filepath
+---
+bool success

--- a/core/catkin_ws/src/custom_msgs/srv/FileUpload.srv
+++ b/core/catkin_ws/src/custom_msgs/srv/FileUpload.srv
@@ -1,0 +1,10 @@
+# Google Drive id of folder under which uploaded file will be placed under
+string folder_id
+
+# Name of uploaded file in Google Drive
+string drive_filename
+
+# Package URL or local filepath of file to upload
+string filepath
+---
+bool success

--- a/onboard/catkin_ws/src/google_drive/CMakeLists.txt
+++ b/onboard/catkin_ws/src/google_drive/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(google_drive)
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED
+  rospy
+  custom_msgs
+  resource_retriever
+)
+
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+catkin_package(CATKIN_DEPENDS rospy custom_msgs resource_retriever)

--- a/onboard/catkin_ws/src/google_drive/README.md
+++ b/onboard/catkin_ws/src/google_drive/README.md
@@ -1,0 +1,42 @@
+# Google Drive ROS package
+
+This package contains a script to download and upload files to Google Drive. Note that you cannot upload/download G Suite files (e.g. Google docs. Google sheets), but can upload/download any other type of file.
+
+## Usage
+
+### First-time setup
+To initialize your google account for use with this script, follow steps 6 and 7 of this [tutorial](https://codelabs.developers.google.com/codelabs/gsuite-apis-intro/#5).
+
+At the end of step 7, you should have downloaded a file with a long name in form `client_secret_LONG_HEX_VALUE.json`. Rename this file to `client_secret.json` and move it into the secrets folder of this package.
+
+This setup will only need to be performed once for your account, for subsequent uses, you merely need to download the `client_secret.json` file.
+
+### Starting the service
+
+To start the node, call
+```bash
+rosrun google_drive file_transfer.py --noauth_local_webserver
+```
+If this is your first time authenticating to Drive, you will be asked to go to a link to authorize permissions. Follow the instructions printed. Once you have authenticated successfully, you will be able to call the services.
+
+**DELETE `client_secret.json` AND `storage.json` ONCE YOU HAVE FINISHED YOUR DOWNLOAD/UPLOAD. ACCIDENTALLY COMMITTING THESE FILES CAN COMPROMISE YOUR GOOGLE DRIVE.** 
+
+These files will be located in the secrets folder.
+### Download a file
+
+After you have started the node, you may use
+```bash
+rosservice call /file_download "{file_id: '<file_id>', filepath: '<filepath>'}"
+```
+Here, `<file_id>` is google drive id of the file you wish to download. The `<filepath>` can either be the package url or the absolute filepath of the location of where to save the file.
+
+Note: to get the `<file_id>`, you can look at the url in Drive, which will look like `https://drive.google.com/file/d/<file_id>/view`. You may need to open the file in a new windows by clicking the three dots in the upper right corner and clicking 'open in a new window'. You can also look at the shareable link.
+
+### Upload a file
+After you have started the node, you may use
+```bash
+rosservice call /file_upload "{folder_id: '<folder_id>', drive_filename: '<drive_filename>', filepath: '<filepath>'}"
+```
+Here, `<folder_id>` is google drive id of the parent folder under which to upload the file to. The `<drive_filename>` is the name the you want the file to have in Google Drive. The `<filepath>` can either be the package url or the absolute filepath of the file you wish to upload.
+
+Note: All uploads must be placed in a pre-existing folder on Drive, you cannot upload to the root directory of your Drive. To get the `<folder_id>`, you can look at the url in Drive, which will look like `https://drive.google.com/drive/folders/<folder_id>`.

--- a/onboard/catkin_ws/src/google_drive/README.md
+++ b/onboard/catkin_ws/src/google_drive/README.md
@@ -1,13 +1,13 @@
 # Google Drive ROS package
 
-This package contains a script to download and upload files to Google Drive. Note that you cannot upload/download G Suite files (e.g. Google docs. Google sheets), but can upload/download any other type of file.
+This package contains a script to download and upload files to Google Drive. Note that you cannot upload/download G Suite files (e.g. Google docs, Google sheets), but can upload/download any other type of file.
 
 ## Usage
 
 ### First-time setup
 To initialize your google account for use with this script, follow steps 6 and 7 of this [tutorial](https://codelabs.developers.google.com/codelabs/gsuite-apis-intro/#5).
 
-At the end of step 7, you should have downloaded a file with a long name in form `client_secret_LONG_HEX_VALUE.json`. Rename this file to `client_secret.json` and move it into the secrets folder of this package.
+At the end of step 7, you should have downloaded a file with a long name in form `client_secret_LONG_HEX_VALUE.json`. Rename this file to `client_secret.json` and move it into the `secrets` folder of this package.
 
 This setup will only need to be performed once for your account, for subsequent uses, you merely need to download the `client_secret.json` file.
 
@@ -30,7 +30,7 @@ rosservice call /file_download "{file_id: '<file_id>', filepath: '<filepath>'}"
 ```
 Here, `<file_id>` is google drive id of the file you wish to download. The `<filepath>` can either be the package url or the absolute filepath of the location of where to save the file.
 
-Note: to get the `<file_id>`, you can look at the url in Drive, which will look like `https://drive.google.com/file/d/<file_id>/view`. You may need to open the file in a new windows by clicking the three dots in the upper right corner and clicking 'open in a new window'. You can also look at the shareable link.
+Note: to get the `<file_id>`, you can look at the url in Drive, which will look like `https://drive.google.com/file/d/<file_id>/view`. You may need to open the file in a new window by clicking the three dots in the upper right corner and clicking 'open in a new window'. You can also look at the shareable link.
 
 ### Upload a file
 After you have started the node, you may use

--- a/onboard/catkin_ws/src/google_drive/package.xml
+++ b/onboard/catkin_ws/src/google_drive/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>google_drive</name>
+  <version>0.0.0</version>
+  <description>
+    This package contains various tools to
+  </description>
+
+  <maintainer email="hello@duke-robotics.com">Duke Robotics Club</maintainer>
+
+  <license>MIT</license>
+
+  <depend>rospy</depend>
+  <depend>custom_msgs</depend>
+  <depend>resource_retriever</depend>
+
+  <exec_depend>googleapiclient</exec_depend>
+  <exec_depend>httplib2</exec_depend>
+  <exec_depend>oauth2client</exec_depend>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+</package>

--- a/onboard/catkin_ws/src/google_drive/package.xml
+++ b/onboard/catkin_ws/src/google_drive/package.xml
@@ -3,7 +3,7 @@
   <name>google_drive</name>
   <version>0.0.0</version>
   <description>
-    This package contains various tools to
+    This package contains a script to download and upload files to Google Drive.
   </description>
 
   <maintainer email="hello@duke-robotics.com">Duke Robotics Club</maintainer>

--- a/onboard/catkin_ws/src/google_drive/scripts/file_transfer.py
+++ b/onboard/catkin_ws/src/google_drive/scripts/file_transfer.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import rospy
+from custom_msgs.srv import FileDownload, FileUpload
+from google_drive import GoogleDrive
+import resource_retriever as rr
+
+
+class FileTransfer:
+
+    def __init__(self):
+        rospy.init_node('file_transfer_server')
+        rospy.Service('file_download', FileDownload, self.download_service)
+        rospy.Service('file_upload', FileUpload, self.upload_service)
+        storage_path = rr.get_filename('package://google_drive/secrets/storage.json', use_protocol=False)
+        client_secret_path = rr.get_filename('package://google_drive/secrets/client_secret.json', use_protocol=False)
+        self.drive = GoogleDrive(storage_path, client_secret_path)
+        rospy.spin()
+
+    def download_service(self, req):
+        filepath = rr.get_filename(req.filepath, use_protocol=False)
+        self.drive.download(req.file_id, filepath)
+        return {'success': True}
+
+    def upload_service(self, req):
+        filepath = rr.get_filename(req.filepath, use_protocol=False)
+        self.drive.upload(req.drive_filename, req.folder_id, filepath)
+        return {'success': True}
+
+
+if __name__ == '__main__':
+    FileTransfer()

--- a/onboard/catkin_ws/src/google_drive/scripts/google_drive.py
+++ b/onboard/catkin_ws/src/google_drive/scripts/google_drive.py
@@ -1,0 +1,36 @@
+from googleapiclient import discovery
+from googleapiclient.http import MediaIoBaseDownload, MediaFileUpload
+from httplib2 import Http
+from oauth2client import file, client, tools
+import io
+
+
+class GoogleDrive:
+
+    SCOPES = 'https://www.googleapis.com/auth/drive'
+
+    def __init__(self, storage_path, client_secret_path):
+        store = file.Storage(storage_path)
+        creds = store.get()
+        if not creds or creds.invalid:
+            flow = client.flow_from_clientsecrets(client_secret_path, self.SCOPES)
+            creds = tools.run_flow(flow, store)
+        self.drive = discovery.build('drive', 'v3', http=creds.authorize(Http()))
+
+    def download(self, file_id, filepath):
+        request = self.drive.files().get_media(fileId=file_id)
+        fh = io.FileIO(filepath, mode='wb')
+        downloader = MediaIoBaseDownload(fh, request)
+        done = False
+        while not done:
+            status, done = downloader.next_chunk()
+            print("Download %d%%." % int(status.progress() * 100))
+
+    def upload(self, drive_filename, folder_id, filepath):
+        file_metadata = {
+            'name': drive_filename,
+            'parents': [folder_id]
+        }
+        media = MediaFileUpload(filepath, resumable=True)
+        drive_file = self.drive.files().create(body=file_metadata, media_body=media, fields='id').execute()
+        print('File ID: %s' % drive_file.get('id'))

--- a/onboard/catkin_ws/src/google_drive/secrets/.gitignore
+++ b/onboard/catkin_ws/src/google_drive/secrets/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this folder
+*
+
+# Except for this gitignore file
+!.gitignore


### PR DESCRIPTION
This provides a package to upload and download files from Google Drive.

The main use case is during pool testing, when we need to download a large file from drive (like a CV model). Currently, we have to  download it onto our computer (which could be very slow if we do not want to disconnect from the robots network and connect to DukeVisitor), and then use scp or ftp to transfer the file onto the robot, which could again be slow with a bad tether connection. This package basically bypasses our tether/router and downloads the file directly into the container, potentially saving us valuable time during pool tests.