### PR TITLE
Fix message types in offboard_comms

### DIFF
--- a/onboard/catkin_ws/src/offboard_comms/Arduino Sketchbooks/ThrusterServoArduino/ThrusterServoArduino.ino
+++ b/onboard/catkin_ws/src/offboard_comms/Arduino Sketchbooks/ThrusterServoArduino/ThrusterServoArduino.ino
@@ -21,13 +21,13 @@ MultiplexedBasicESC *thrusters[NUM_THRUSTERS];
 MultiplexedServo *servos[NUM_SERVO];
 
 // reusing ESC library code
-void thruster_speeds_callback(const offboard_comms::ThrusterSpeeds &ts_msg){
+void thruster_speeds_callback(const custom_msgs::ThrusterSpeeds &ts_msg){
     //copy the contents of the speed message to the local array
     memcpy(thruster_speeds, ts_msg.speeds, sizeof(thruster_speeds));
     last_cmd_ms_ts = millis();
 }
 
-void servo_control_callback(const offboard_comms::SetServo::Request &sc_req, offboard_comms::SetServo::Response &sc_res){
+void servo_control_callback(const custom_msgs::SetServo::Request &sc_req, custom_msgs::SetServo::Response &sc_res){
     //copy the contents of the servo request to the local variables
     uint8_t pin = sc_req.num;
     uint16_t angle = sc_req.angle;
@@ -41,8 +41,8 @@ void servo_control_callback(const offboard_comms::SetServo::Request &sc_req, off
 
 //Sets node handle to have 2 subscribers, 2 publishers, and 150 bytes for input and output buffer
 ros::NodeHandle_<ArduinoHardware,2,2,150,150> nh;  
-ros::Subscriber<offboard_comms::ThrusterSpeeds> ts_sub("/offboard/thruster_speeds", &thruster_speeds_callback);
-ros::ServiceServer<offboard_comms::SetServo::Request, offboard_comms::SetServo::Response> servo_service("/offboard/servo_angle", &servo_control_callback);
+ros::Subscriber<custom_msgs::ThrusterSpeeds> ts_sub("/offboard/thruster_speeds", &thruster_speeds_callback);
+ros::ServiceServer<custom_msgs::SetServo::Request, custom_msgs::SetServo::Response> servo_service("/offboard/servo_angle", &servo_control_callback);
 
 void setup(){
     Serial.begin(BAUD_RATE);

--- a/onboard/catkin_ws/src/offboard_comms/README.md
+++ b/onboard/catkin_ws/src/offboard_comms/README.md
@@ -23,7 +23,7 @@ rosrun rosserial_python serial_node.py /dev/ttyUSB0
 ```
 Now to test, start sending messages to the offboard device. For instance, to run all the thrusters at speed 0, you can use:
 ```
-rostopic pub -r 10 /offboard/thruster_speeds offboard_comms/ThrusterSpeeds '{speeds: [0,0,0,0,0,0,0,0]}'
+rostopic pub -r 10 /offboard/thruster_speeds custom_msgs/ThrusterSpeeds '{speeds: [0,0,0,0,0,0,0,0]}'
 ```
 To set the first servo to a 90 degree angle, you can use:
 ```
@@ -32,8 +32,8 @@ rosservice call /offboard/servo_angle '{num: 0, angle: 90}'
 
 ## Topics and Services
 ### Thrusters
-The thrusters are subscribed to the `/offboard/thruster_speeds` topic that is of type `offboard_comms/ThrusterSpeeds.msg`. This is an array of 8 signed 8-bit integers, which have range of [-128,127]. Negative values correspond to reverse (<1500 microseconds PWM), and positive values correspond to forward (>1500 microseconds PWM). 
+The thrusters are subscribed to the `/offboard/thruster_speeds` topic that is of type `custom_msgs/ThrusterSpeeds.msg`. This is an array of 8 signed 8-bit integers, which have range of [-128,127]. Negative values correspond to reverse (<1500 microseconds PWM), and positive values correspond to forward (>1500 microseconds PWM). 
 ### Servos
-The servos utilize the  `/offboard/servo_angle` service that is of type `offboard_comms/SetServo.srv`. The request to this service consists of an unsigned 8-bit integer `num` that corresponds to the pin number of the servo, and an unsigned 16 bit integer `angle` that corresponds to the desired angle (0-180). The reply consists of a bool `success` that corresponds to whether the request successfully set the angle.
+The servos utilize the  `/offboard/servo_angle` service that is of type `custom_msgs/SetServo.srv`. The request to this service consists of an unsigned 8-bit integer `num` that corresponds to the pin number of the servo, and an unsigned 16 bit integer `angle` that corresponds to the desired angle (0-180). The reply consists of a bool `success` that corresponds to whether the request successfully set the angle.
 
 Values for `num` are 0-indexed (meaning the first servo corresponds to pin number 0) and values that are greater than or equal to the number of servos will result in an unsuccessfull call. Values for `angle` that are >180 will also result in an unsuccessful call.


### PR DESCRIPTION
This fixes the message types in offboard_comms to derive from package custom_msgs. I changed the header file, but forgot to change the message definitions when moving to the new package structure. This also fixes the naming in the readme.