### PR TITLE
Update Simulation README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Our codebase is split into two repositories:
 1. This repo contains all of the code required for running and testing our robots.
 1. The [documentation](https://github.com/DukeRobotics/documentation) repo contains introductory projects, tutorials, and miscellaneous docs.
 
-Our code is Dockerized, making it straightforward to set up and run. See [Running Docker Images](#running-docker-images).
+Our code is Dockerized, making it straightforward to set up and run. See [Running Our Docker Images](#running-our-docker-images).
 
-Once the containers are up and running, go to [Running our Code](#running-our-code).
+Once the containers are up and running, go to [Running Our Code](#running-our-code).
 
 
 ## Software Stack
@@ -36,7 +36,7 @@ The following components make up our software stack:
 - Landside:
     * [Camera View](landside/catkin_ws/src/camera_view) - Package that allows for viewing, saving, and loading videos to simulate camera input.
     * [Joystick](landside/catkin_ws/src/joystick) - Allows manual joystick control for testing.
-    * [Simulation](simulation) - Physics-enabled simulation that can be used for local testing. (not in landside, but run using the landside container)
+    * [Simulation](simulation) - Physics-enabled simulation that can be used for local testing. (not in the landside workspace, but run using the landside container)
 
 
 ## Flow
@@ -115,6 +115,7 @@ Use these instructions when running code on the robot itself.
     ```bash
     source /opt/ros/melodic/setup_network.bash
     ```
+1. Now go to [Running Our Code](#running-our-code).
 
 ### Local Testing
 Use these instructions to test code on your computer by simulating the robot's execution.
@@ -139,6 +140,7 @@ Use these instructions to test code on your computer by simulating the robot's e
     ```bash
     source /opt/ros/melodic/setup_network.bash
     ```
+1. Now go to [Running Our Code](#running-our-code). Also set up our [simulation](simulation).
 1. To stop and delete both containers and their network, in the `robosub-ros` directory, execute
     ```bash
     docker-compose down

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -35,7 +35,7 @@ Make sure you have some version of python installed on your personal computer. *
 
 ## Running the Simulation
 ### Docker Simulation Setup
-1. Open up a terminal and ssh into your Docker Container with the `-XY` flag (i.e. run `ssh -XY -p 2201 duke@localhost`).
+1. Open up a terminal and ssh into your Docker Container with the `-XY` flag (i.e. run `ssh -XY -p 2201 root@localhost`).
 2. Run `source /opt/ros/melodic/setup.bash` and `roscore &`.
 3. Run `cd dev/robosub-ros/simulation` and then `./runSim.sh &` (you may first need to run `chmod +x runSim.sh`). Wait until the terminal says `Initialization successful.` If it delays on the video compression library or meshcalc for an extended period of time, press enter a couple of times. This may be nothing more than confirmation-bias superstition.
 4. Run whatever ROS topic publishing code you have. In `robosub-ros/simulation/docker`, there is a python script `squareCommand.py` that you can run to make the robot move approximately in a square. (In reality, the robot will spin in wide circles because the robot isn't balanced.) You can use this script to test if communication between the simulations is working.

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -7,13 +7,6 @@ Additionally, it publishes a [TwistStamped](http://docs.ros.org/melodic/api/geom
 ### Assumptions
 This readme assumes that you are able to mount the git repo in the docker container, and that you have the most recent Docker image pulled. 
 
-### Setting up the Docker Container
-You will need a Docker container with port 8080 forwarded. You will be using the landside container. Run the command that you normally do to create your Docker container, but with `-p 8080:8080` added.
-    
-For example, you might run the command:
-
-`docker run -td -p 2201:2201 -p 8080:8080 --mount type=bind,source=[source path],target=[mount path] dukerobotics/robosub-ros:landside`
-
 ### Downloading CoppeliaSim on your personal computer
 #### Downloading on Windows
 Download the installer for the Edu version from [this link](http://coppeliarobotics.com/winVersions), and run the downloaded .exe file.
@@ -42,7 +35,7 @@ Make sure you have some version of python installed on your personal computer. *
 
 ## Running the Simulation
 ### Docker Simulation Setup
-1. Open up a terminal and ssh into your Docker Container with the `-XY` flag (i.e. run `ssh -XY -p 2201 duke@[ip address]`).
+1. Open up a terminal and ssh into your Docker Container with the `-XY` flag (i.e. run `ssh -XY -p 2201 duke@localhost`).
 2. Run `source /opt/ros/melodic/setup.bash` and `roscore &`.
 3. Run `cd dev/robosub-ros/simulation` and then `./runSim.sh &` (you may first need to run `chmod +x runSim.sh`). Wait until the terminal says `Initialization successful.` If it delays on the video compression library or meshcalc for an extended period of time, press enter a couple of times. This may be nothing more than confirmation-bias superstition.
 4. Run whatever ROS topic publishing code you have. In `robosub-ros/simulation/docker`, there is a python script `squareCommand.py` that you can run to make the robot move approximately in a square. (In reality, the robot will spin in wide circles because the robot isn't balanced.) You can use this script to test if communication between the simulations is working.
@@ -51,12 +44,7 @@ Make sure you have some version of python installed on your personal computer. *
 1. Open CoppeliaSim.
 2. Go to `File>Open Scene...` and open `empty_scene.ttt` in `robosub-ros/simulation/personal/scenes`.
 3. Press the play button to start the simulation. The robot should start bobbing up and down.
-4. On your computer, run `ros_coppelia_comm.py` at `robosub-ros/simulation/personal`. **If you have a Mac,** you must run this file with Python 3. **If you have Docker Toolbox (i.e. you have Windows, but not Windows 10 Pro, Education, or Enterprise)**, you need to run `ros_coppelia_comm.py` with the command line argument of the IP address of the Docker container (e.g. `ros_coppelia_comm.py 192.168.99.100`). By default this is `192.168.99.100`, but you can find the IP address by running `docker-machine ip` in your Docker Toolbox terminal.
-    <details>
-        <summary>Click for Explanation</summary>        
-        The reason for this is that Docker Toolbox handles the containers, and more specifically, their IP addresses, differently, requiring a different IP address. `192.168.99.100` is the default output of `docker-machine ip`, which is why it is used. If the simulation fails to connect, run `docker-machine ip` to see if the output is the IP address above.        
-    </details>
-
+4. On your computer, run `ros_coppelia_comm.py` at `robosub-ros/simulation/personal`. **If you have a Mac,** you must run this file with Python 3.
 5. If the robot starts moving laterally, it worked!
 
 #### A Note for Windows

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -30,8 +30,8 @@ Make sure you have some version of Python3 installed on your personal computer. 
 
 ## Running the Simulation
 ### Docker Simulation Setup
-1. In the landside container, make sure `roscore` is running.
-2. Run `cd dev/robosub-ros/simulation` and then `./runSim.sh &` (you may first need to run `chmod +x runSim.sh`). Wait until the terminal says `Initialization successful.` If it delays on the video compression library or meshcalc for an extended period of time, press enter a couple of times. This may be nothing more than confirmation-bias superstition.
+1. In the onboard container, make sure `roscore` is running.
+2. In the landside container, run `cd dev/robosub-ros/simulation` and then `./runSim.sh &` (you may first need to run `chmod +x runSim.sh`). Wait until the terminal says `Initialization successful.` If it delays on the video compression library or meshcalc for an extended period of time, press enter a couple of times. This may be nothing more than confirmation-bias superstition.
 3. Run whatever ROS topic publishing code you have. In `robosub-ros/simulation/docker`, there is a Python script `squareCommand.py` that you can run to make the robot move approximately in a square. (In reality, the robot will spin in wide circles because the robot isn't balanced.) You can use this script to test if communication between the simulations is working.
 
 ### Personal Computer Simulation Setup

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -8,13 +8,11 @@ Additionally, it publishes a [TwistStamped](http://docs.ros.org/melodic/api/geom
 This readme assumes that you are able to mount the git repo in the docker container, and that you have the most recent Docker image pulled. 
 
 ### Setting up the Docker Container
-You will need a Docker container with port 8080 forwarded. Additionally, you will need to use the simulation tag for the Docker container. Run the command that you normally do to create your Docker container according to the [documentation repo](https://github.com/DukeRobotics/documentation/tree/master/docker), but with `-p 8080:8080` added, and with `:simulation` at the end.
+You will need a Docker container with port 8080 forwarded. You will be using the landside container. Run the command that you normally do to create your Docker container, but with `-p 8080:8080` added.
     
 For example, you might run the command:
 
-`docker run -td -p 2200:2200 -p 8080:8080 --mount type=bind,source=C:\Users\Eric\Documents\Robotics\CS,target=/home/duke/dev/robosub-ros/src dukerobotics/robosub-ros:simulation`
-    
-[Here's](https://github.com/DukeRobotics/documentation/tree/master/docker) the link to the documentation repo with the Docker commands, if you need to look yours up.
+`docker run -td -p 2201:2201 -p 8080:8080 --mount type=bind,source=[source path],target=[mount path] dukerobotics/robosub-ros:landside`
 
 ### Downloading CoppeliaSim on your personal computer
 #### Downloading on Windows
@@ -44,8 +42,8 @@ Make sure you have some version of python installed on your personal computer. *
 
 ## Running the Simulation
 ### Docker Simulation Setup
-1. Open up a terminal and ssh into your Docker Container with the `-XY` flag (i.e. run `ssh -XY -p 2200 duke@[ip address]`).
-2. Run `source /opt/ros/kinetic/setup.bash` and `roscore &`.
+1. Open up a terminal and ssh into your Docker Container with the `-XY` flag (i.e. run `ssh -XY -p 2201 duke@[ip address]`).
+2. Run `source /opt/ros/melodic/setup.bash` and `roscore &`.
 3. Run `cd dev/robosub-ros/simulation` and then `./runSim.sh &` (you may first need to run `chmod +x runSim.sh`). Wait until the terminal says `Initialization successful.` If it delays on the video compression library or meshcalc for an extended period of time, press enter a couple of times. This may be nothing more than confirmation-bias superstition.
 4. Run whatever ROS topic publishing code you have. In `robosub-ros/simulation/docker`, there is a python script `squareCommand.py` that you can run to make the robot move approximately in a square. (In reality, the robot will spin in wide circles because the robot isn't balanced.) You can use this script to test if communication between the simulations is working.
 

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -5,20 +5,20 @@ Additionally, it publishes a [TwistStamped](http://docs.ros.org/melodic/api/geom
 
 ## Installing the Simulation
 ### Assumptions
-This readme assumes that you are able to mount the git repo in the docker container, and that you have the most recent Docker image pulled. 
+This readme assumes that you are running the Docker containers for [local testing](https://github.com/DukeRobotics/robosub-ros#local-testing).
 
 ### Downloading CoppeliaSim on your personal computer
-#### Downloading on Windows
-Download the installer for the Edu version from [this link](http://coppeliarobotics.com/winVersions), and run the downloaded .exe file.
+First, download CoppeliaSim Edu for your OS version from [this link](https://coppeliarobotics.com/downloads). Then, follow the steps below for your specific OS.
+#### Installing on Windows
+Run the downloaded .exe file.
 
-#### Downloading on Linux
-Download the file for the Edu version for your OS from [this link](http://coppeliarobotics.com/ubuntuVersions), move the tar file to where you'd like the CoppeliaSim folder, and run `tar -kxvf [filename]`.
+#### Installing on Ubuntu
+Move the downloaded tar file to where you'd like the CoppeliaSim folder, and run `tar -kxvf [filename]`.
 
-#### Downloading on Mac
-1. Download the mac version of CoppeliaSim Edu from [this link](http://coppeliarobotics.com/downloads)
-2. Unzip the download and move the resulting folder to Applications
-3. To run, click on coppeliaSim inside of that folder
-4. If you get an error about models not found, run the following at the top of the CoppeliaSim folder
+#### Installing on Mac
+1. Unzip the download and move the resulting folder to Applications
+2. To run, click on CoppeliaSim inside of that folder
+3. If you get an error about models not found, run the following at the top of the CoppeliaSim folder
 ```bash
 sudo xattr -r -d com.apple.quarantine *
 ```
@@ -26,29 +26,23 @@ sudo xattr -r -d com.apple.quarantine *
 ### Downloading Remaining Files
 You'll be using files in `robosub-ros/simulation/personal`.
 
-Make sure you have some version of python installed on your personal computer. **If you have a Mac, you must have Python 3!** You can download and install it at [this link](https://www.python.org/downloads/release/python-381/).
-
-<details>
-    <summary>Click for Explanation of Python3</summary>
-    You will need to run a python script on your personal computer (either from command line or from IDE) to have the simulations communicate with each other. For Macs, this script uses a library, which can cause permission errors when run by restricted programs. Because Python 2 is deprecated, it is a restricted program, while Python 3 is not.
-</details>
+Make sure you have some version of Python3 installed on your personal computer. You can download and install it at [this link](https://www.python.org/downloads/release/python-381/).
 
 ## Running the Simulation
 ### Docker Simulation Setup
-1. Open up a terminal and ssh into your Docker Container with the `-XY` flag (i.e. run `ssh -XY -p 2201 root@localhost`).
-2. Run `source /opt/ros/melodic/setup.bash` and `roscore &`.
-3. Run `cd dev/robosub-ros/simulation` and then `./runSim.sh &` (you may first need to run `chmod +x runSim.sh`). Wait until the terminal says `Initialization successful.` If it delays on the video compression library or meshcalc for an extended period of time, press enter a couple of times. This may be nothing more than confirmation-bias superstition.
-4. Run whatever ROS topic publishing code you have. In `robosub-ros/simulation/docker`, there is a python script `squareCommand.py` that you can run to make the robot move approximately in a square. (In reality, the robot will spin in wide circles because the robot isn't balanced.) You can use this script to test if communication between the simulations is working.
+1. In the landside container, make sure `roscore` is running.
+2. Run `cd dev/robosub-ros/simulation` and then `./runSim.sh &` (you may first need to run `chmod +x runSim.sh`). Wait until the terminal says `Initialization successful.` If it delays on the video compression library or meshcalc for an extended period of time, press enter a couple of times. This may be nothing more than confirmation-bias superstition.
+3. Run whatever ROS topic publishing code you have. In `robosub-ros/simulation/docker`, there is a Python script `squareCommand.py` that you can run to make the robot move approximately in a square. (In reality, the robot will spin in wide circles because the robot isn't balanced.) You can use this script to test if communication between the simulations is working.
 
 ### Personal Computer Simulation Setup
 1. Open CoppeliaSim.
 2. Go to `File>Open Scene...` and open `empty_scene.ttt` in `robosub-ros/simulation/personal/scenes`.
 3. Press the play button to start the simulation. The robot should start bobbing up and down.
-4. On your computer, run `ros_coppelia_comm.py` at `robosub-ros/simulation/personal`. **If you have a Mac,** you must run this file with Python 3.
+4. In `robosub-ros/simulation/personal` on your local machine, run `python3 run_coppelia_comm.py`.
 5. If the robot starts moving laterally, it worked!
 
 #### A Note for Windows
-On windows machines with high res displays, some apps will not scale the font correctly. This happens because some applications essentially “tell” windows that it will handle the scaling, but then don’t. To fix this, right click on the application icon, go to properties, compatibility, change high DPI settings, check override, and select system.
+On Windows machines with high res displays, some apps will not scale the font correctly. This happens because some applications essentially “tell” Windows that it will handle the scaling, but then don’t. To fix this, right click on the application icon, go to properties, compatibility, change high DPI settings, check override, and select system.
 
 ## Stopping/Shutting down the Simulation
 To pause the simulation, just press the pause button to pause, and press play to resume.


### PR DESCRIPTION
The previous README had a link to the docker documentation (which commands to run, which image to use, etc.) which apparently no longer exists. Aside from that, the readme has been completely updated for the new docker setup.