### PR TITLE
Clean argument for build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,13 @@ Here are some common launch configurations for both pool and local testing.
         ```
 
 ### Cleaning Build
-To clean the build outputs from a workspace (build, devel, and logs folders), in `robosub-ros/<workspace>/catkin_ws`, execute
+To clean the build outputs from a workspace (build, devel, and logs folders), in the `~/dev/robosub-ros` directory, execute
 ```bash
-catkin clean
+./build.sh clean <workspace>
+```
+where `<workspace>` is either onboard or landside. If you would like to clean all workspaces, then you may simply execute
+```bash
+./build.sh clean
 ```
 
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,32 @@
 #!/bin/bash
-# A convenience script used to build our code. Takes one argument that specifies the workspace to build.
+# A convenience script used to build our code.
+# Takes one argument that specifies the workspace to build when used to build.
+# When used to clean, argument 1 should be clean, and argument 2, if present is the workspace to clean.
+# If argument 2 is omitted when cleaning, then all workspaces will be cleaned.
 
 set -e
+
+# Handle cleaning
+if [[ "$1" == "clean" ]]; then
+  if [[ -z "$2" ]] || [[ "$2" == "onboard" ]]; then
+    cd onboard/catkin_ws
+    catkin clean -y
+    cd ../..
+  fi
+
+  if [[ -z "$2" ]] || [[ "$2" == "landside" ]]; then
+    cd landside/catkin_ws
+    catkin clean -y
+    cd ../..
+  fi
+
+  if [[ -z "$2" ]]; then
+    cd core/catkin_ws
+    catkin clean -y
+    cd ../..
+  fi
+  exit 0
+fi
 
 # Print help message on invalid argument
 if [[ "$1" != "onboard" ]] && [[ "$1" != "landside" ]]; then


### PR DESCRIPTION
Closes #228.
Although it's not mentioned in the issue, I decided to add the option of using a second argument to clean a specific workspace, just for convenience. 