### PR TITLE
Add updated info to the CV README

### DIFF
--- a/onboard/catkin_ws/src/cv/README.md
+++ b/onboard/catkin_ws/src/cv/README.md
@@ -78,6 +78,9 @@ Once 1+ models are enabled for a specific node, they listen and publish to topic
   * For each detected object in a frame, the model will publish the `xmin`, `ymin`, `xmax`, and `ymax` 
     coordinates (normalized to \[0, 1\]), `label` of the object, `score` (a confidence value in the range
     of \[0, 1\]), and the `width` and `height` of the frame. 
+    * Note: Only the highest-confidence prediction of each label type is published (e.g. if 5 bounding boxes 
+      were predicted for a gate object, only the one with the highest score is chosen)
+  * If a model is enabled but detects no objects in a frame, it will publish a message with the label field set to 'none'
   * Type: custom_msgs/CVObject
 
 Note that the camera feed frame rate will likely be greater than the rate at which predictions can 


### PR DESCRIPTION
### List of Changes

* Add info explaining how only the highest-confidence prediction of each label type is published
* Add info explaining how a message with label field 'none' is published if a model is enabled that detects no objects in a frame