### PR TITLE
Update pip install around version 21.1

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -2,6 +2,15 @@
 
 set -ex
 
+sudo apt-get remove docker docker-engine docker.io containerd runc
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+sudo apt-get update
+sudo apt-get install docker-ce=5:19.03.15~3-0~ubuntu-bionic docker-ce-cli=5:19.03.15~3-0~ubuntu-bionic containerd.io
+
 # Use experimental Docker
 sudo jq -n '{experimental: true}' | sudo tee /etc/docker/daemon.json > /dev/null
 sudo systemctl restart docker

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+sudo apt-get update
 sudo apt-get remove docker docker-engine docker.io containerd runc
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
     steps:
@@ -25,7 +25,7 @@ jobs:
             - '.github/workflows/**'
 
   core-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: check-docker
     if: needs.check-docker.outputs.docker == 'true'
     strategy:
@@ -58,7 +58,7 @@ jobs:
           path: ${{ env.FILE_NAME }}
 
   onboard-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: core-docker
     strategy:
       matrix:
@@ -105,7 +105,7 @@ jobs:
           docker push ${IMAGE_NAME}
 
   push-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: [onboard-docker, landside-docker]
     steps:
       - uses: actions/checkout@v2
@@ -122,7 +122,7 @@ jobs:
         run: ./.github/workflows/cleanup.sh
 
   landside-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: core-docker
     env:
       IMAGE_NAME: dukerobotics/robosub-ros:landside
@@ -164,7 +164,7 @@ jobs:
           docker push ${IMAGE_NAME}
 
   build-without-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: check-docker
     if: needs.check-docker.outputs.docker == 'false'
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
     steps:
@@ -25,7 +25,7 @@ jobs:
             - '.github/workflows/**'
 
   core-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: check-docker
     if: needs.check-docker.outputs.docker == 'true'
     strategy:
@@ -58,7 +58,7 @@ jobs:
           path: ${{ env.FILE_NAME }}
 
   onboard-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: core-docker
     strategy:
       matrix:
@@ -105,7 +105,7 @@ jobs:
           docker push ${IMAGE_NAME}
 
   push-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: [onboard-docker, landside-docker]
     steps:
       - uses: actions/checkout@v2
@@ -122,7 +122,7 @@ jobs:
         run: ./.github/workflows/cleanup.sh
 
   landside-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: core-docker
     env:
       IMAGE_NAME: dukerobotics/robosub-ros:landside
@@ -164,7 +164,7 @@ jobs:
           docker push ${IMAGE_NAME}
 
   build-without-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: check-docker
     if: needs.check-docker.outputs.docker == 'false'
     strategy:

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
 
 # Install pip
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py && \
+    python3 get-pip.py && \
     python -m pip install pip==8.1.1 
 
 # Set up locales

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -65,8 +65,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
 
 # Install pip
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python3 get-pip.py && \
-    python -m pip install pip==8.1.1 
+    python3 get-pip.py pip==8.1.1
 
 # Set up locales
 RUN locale-gen en_GB.UTF-8 && locale-gen en_US.UTF-8

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -56,16 +56,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
     usbutils \
     apt-utils \
     python-catkin-tools \
+    python-pip \
     ros-melodic-cv-bridge \
     ros-melodic-resource-retriever \
     locales && \
     apt-get clean && \
     # Clear apt caches to reduce image size
     rm -rf /var/lib/apt/lists/*
-
-# Install pip
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python3 get-pip.py pip==8.1.1
 
 # Set up locales
 RUN locale-gen en_GB.UTF-8 && locale-gen en_US.UTF-8

--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Get required python packages
+RUN pip install Cython
 RUN pip install pyserial dependency-injector pillow==6 pymba==0.1 numpy==1.18.1
 
 # Install PyTorch and Torchvision

--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Get required python packages
-RUN pip install pyserial dependency-injector pillow==6 pymba==0.1 numpy==1.19.5
+RUN pip install pyserial dependency-injector pillow==6 pymba==0.1 numpy==1.18.1
 
 # Install PyTorch and Torchvision
 COPY $TARGETPLATFORM/TorchInstaller.sh TorchInstaller.sh

--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Get required python packages
+RUN pip install Cython
 RUN pip install pyserial dependency-injector pillow==6 pymba==0.1 numpy==1.19.5
 
 # Install PyTorch and Torchvision

--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -25,8 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Get required python packages
-RUN pip install Cython
-RUN pip install pyserial dependency-injector pillow==6 pymba==0.1 numpy==1.18.1
+RUN pip install pyserial dependency-injector pillow==6 pymba==0.1
 
 # Install PyTorch and Torchvision
 COPY $TARGETPLATFORM/TorchInstaller.sh TorchInstaller.sh

--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Get required python packages
-RUN pip install Cython
 RUN pip install pyserial dependency-injector pillow==6 pymba==0.1 numpy==1.19.5
 
 # Install PyTorch and Torchvision

--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -33,7 +33,8 @@ RUN ./TorchInstaller.sh && \
     rm TorchInstaller.sh
 
 # Install Detecto
-RUN pip install --no-cache-dir --no-deps detecto
+RUN pip install --upgrade pip==8.1.1 && \
+    pip install --no-cache-dir --no-deps detecto
 
 ### ROS Plugins and Dependencies###
 

--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Get required python packages
-RUN pip install pyserial dependency-injector pillow==6 pymba==0.1
+RUN pip install pyserial dependency-injector pillow==6 pymba==0.1 numpy==1.19.5
 
 # Install PyTorch and Torchvision
 COPY $TARGETPLATFORM/TorchInstaller.sh TorchInstaller.sh

--- a/docker/onboard/linux/arm64/TorchInstaller.sh
+++ b/docker/onboard/linux/arm64/TorchInstaller.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
 # Install Pytorch for ARM using nvidia's providied package for the jetson
-pip install --upgrade setuptool
 wget https://nvidia.box.com/shared/static/1v2cc4ro6zvsbu0p8h6qcuaqco1qcsif.whl -O torch-1.4.0-cp27-cp27mu-linux_aarch64.whl
-apt-get update && apt-get install -y --no-install-recommends libopenblas-base
-pip install --no-cache-dir torch-1.4.0-cp27-cp27mu-linux_aarch64.whl
+apt-get update && apt-get install -y --no-install-recommends libopenblas-base libopenmpi-dev 
+pip install --no-cache-dir future torch-1.4.0-cp27-cp27mu-linux_aarch64.whl
 rm torch-1.4.0-cp27-cp27mu-linux_aarch64.whl
 
 # Install torchvision
-pip install --no-cache-dir future torchvision==0.5.0
+pip install --no-cache-dir future torchvision

--- a/docker/onboard/linux/arm64/TorchInstaller.sh
+++ b/docker/onboard/linux/arm64/TorchInstaller.sh
@@ -8,4 +8,4 @@ pip install --no-cache-dir torch-1.4.0-cp27-cp27mu-linux_aarch64.whl
 rm torch-1.4.0-cp27-cp27mu-linux_aarch64.whl
 
 # Install torchvision
-pip install --no-cache-dir future torchvision
+pip install --no-cache-dir future torchvision==0.5.0

--- a/docker/onboard/linux/arm64/TorchInstaller.sh
+++ b/docker/onboard/linux/arm64/TorchInstaller.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Install Pytorch for ARM using nvidia's providied package for the jetson
+pip install --upgrade setuptool
 wget https://nvidia.box.com/shared/static/1v2cc4ro6zvsbu0p8h6qcuaqco1qcsif.whl -O torch-1.4.0-cp27-cp27mu-linux_aarch64.whl
 apt-get update && apt-get install -y --no-install-recommends libopenblas-base
 pip install --no-cache-dir torch-1.4.0-cp27-cp27mu-linux_aarch64.whl


### PR DESCRIPTION
Updates pip install for to use apt instead of 21.1. This fixes the CI that has been broken on docker builds for the last month.
Ties CI down to Ubuntu 18.04.
Ties docker down to 19.03.