### PR TITLE
Add TopicNames

### DIFF
--- a/core/catkin_ws/src/custom_msgs/msg/TopicNames.msg
+++ b/core/catkin_ws/src/custom_msgs/msg/TopicNames.msg
@@ -1,0 +1,76 @@
+# This message contains the names of all of the topics we use
+
+std_msgs/Header header
+
+# Sensors
+# If changed, also change sensor_fusion\params\main.yaml and data_pub\README.md
+string sensors_imu_imu=sensors/imu/imu
+# If changed, also change data_pub\README.md
+string sensors_imu_mag=sensors/imu/mag
+# If changed, also change data_pub\README.md
+string sensors_dvl_raw=sensors/dvl/raw
+# If changed, also change sensor_fusion\params\main.yaml and data_pub\README.md
+string sensors_dvl_odom=sensors/dvl/odom
+string sensors_depth=sensors/depth
+
+# Controls
+# If changed, also change README.md and controls\README.md
+string state=/state
+string state_local=/state_local
+# If changed, also change controls\README.md
+string controls_desired_pose=controls/desired_pose
+# If changed, also change controls\README.md
+string controls_desired_twist=controls/desired_twist
+# If changed, also change controls\README.md and joystick\README.md
+string controls_desired_power=controls/desired_power
+
+# The following are all meant to be used with .format(axis)
+# If they are changed, also change their variants in controls\launch\position_pid.launch
+string controls_enable_pos=/controls/enable/{}_pos
+string controls_vel_setpoint=/controls/{}_vel/setpoint
+string controls_state_pose=/controls/state/pose/
+
+# The following are all meant to be used with .format(axis)
+# If they are changed, also change their variants in controls\launch\velocity_pid.launch
+string controls_enable_vel=/controls/enable/{}_vel
+string control_effort=/control_effort/{}
+string controls_state_twist=/controls/state/twist/{}
+
+# The following are all meant to be used with .format(axis)
+string controls_pos_setpoint=/controls/{}_pos/setpoint
+string controls_power=/controls/power/{}
+
+# Offboard
+# If changed, also change controls\README.md and offboard_comms\README.md
+string offboard_thruster_speeds=/offboard/thruster_speeds
+# If changed, also change offboard_comms\README.md
+string offboard_servo_angles=/offboard/servo_angles
+string offboard_pressure=/offboard/pressure
+
+# Joystick
+# If changed, also change joystick\launch\joystick_raw.launch
+string joystick_raw=joystick/raw
+
+# Simulation
+# If changed, also change simulation\README.md
+string sim_move=/sim/move
+# If changed, also change simulation\README.md
+string sim_dvl=/sim/dvl
+# If changed, also change simulation\README.md and simulation\personal\scenes\README.md
+string sim_pose=/sim/pose
+# If changed, also change simulation\README.md
+string sim_imu=/sim/imu
+string sim_test_array=/sim/test_array
+string sim_object_points=/sim/object_points
+
+# Camera
+# If changed, also change camera_view\README.md, avt_camera\README.md, and cv\README.md
+string camera_image_raw=/camera/{}/image_raw
+# If changed, also change avt_camera\README.md
+string camera_camera_info=/camera/{}/camera_info
+
+# CV
+# If changed, also change cv\README.md and cv\models\models.yaml
+string cv_buoy=/cv/buoy
+string cv_start_gate_left=/cv/_start_gate/left
+string cv_start_tick_left=/cv/_start_tick/left

--- a/landside/catkin_ws/src/camera_view/README.md
+++ b/landside/catkin_ws/src/camera_view/README.md
@@ -10,9 +10,9 @@ rosrun image_view image_view image:=<image_topic>
 ```
 where `image_topic` is the topic of the published video stream. For example, to view the downward camera, you would use
 ```bash
-rosrun image_view image_view image:=/camera/down/raw_image
+rosrun image_view image_view image:=/camera/down/image_raw
 ```
-where the subscribed topic is `/camera/down/raw_image`.
+where the subscribed topic is `/camera/down/image_raw`.
 
 ### Stereo Video Stream
 You can view a stream from stereo cameras using the command
@@ -21,9 +21,9 @@ rosrun image_view stereo_view stereo:=<stereo_namespace> image:=<image_topic>
 ```
 where stereo namespace represents the overall namespace of the cameras and image topic is the specific image identifier. For example, to view our left/right stereo cams you would use
 ```bash
-rosrun image_view stereo_view stereo:=camera image:=raw_image
+rosrun image_view stereo_view stereo:=camera image:=image_raw
 ```
-where the subscribed topics are `/camera/left/raw_image` and `/camera/right/raw_image`.
+where the subscribed topics are `/camera/left/image_raw` and `/camera/right/image_raw`.
 
 ## Saving Videos
 ### ROS bags
@@ -33,7 +33,7 @@ rosbag record -O output_name <topic_names>
 ```
 where `output_name` is the name of the output file and `topic_names` are a list of topics to record. For example, to record the downward camera, use
 ```bash
-rosbag record -O down_cam.bag /camera/down/raw_image
+rosbag record -O down_cam.bag /camera/down/image_raw
 ```
 
 ### Video converter

--- a/landside/catkin_ws/src/joystick/scripts/joystick.py
+++ b/landside/catkin_ws/src/joystick/scripts/joystick.py
@@ -2,6 +2,7 @@
 
 import rospy
 import yaml
+from custom_msgs.msg import TopicNames
 from geometry_msgs.msg import Twist
 from sensor_msgs.msg import Joy
 from enum import Enum
@@ -15,8 +16,8 @@ class Movement(Enum):
 
 class JoystickParser:
     NODE_NAME = 'joy_pub'
-    JOYSTICK_RAW_TOPIC = 'joystick/raw'
-    JOY_DEST_TOPIC = 'controls/desired_power'
+    JOYSTICK_RAW_TOPIC = TopicNames.joystick_raw
+    JOY_DEST_TOPIC = TopicNames.controls_desired_power
 
     def __init__(self):
         self._pub = rospy.Publisher(self.JOY_DEST_TOPIC, Twist, queue_size=50)

--- a/landside/catkin_ws/src/simulation/docker/comm_code.lua
+++ b/landside/catkin_ws/src/simulation/docker/comm_code.lua
@@ -1,11 +1,13 @@
 require "math"
+require "roslua"
 
 function extsysCall_init()
     h=sim.getObjectAssociatedWithScript(sim.handle_self)
     m=sim.getShapeMassAndInertia(h)
     simRemoteApi.start(8080)
 
-    moveSub=simROS.subscribe('/sim/move', 'std_msgs/Float32MultiArray', 'move_callback')
+	topicNamesSpec = roslua.get_msgspec("custom_msgs.msg/TopicNames")
+    moveSub=simROS.subscribe(topicNamesSpec.sim_move, 'std_msgs/Float32MultiArray', 'move_callback')
     simROS.subscriberTreatUInt8ArrayAsString(moveSub)
 
     HEAD_FLAG = -525600

--- a/landside/catkin_ws/src/simulation/personal/scenes/pub_code.lua
+++ b/landside/catkin_ws/src/simulation/personal/scenes/pub_code.lua
@@ -1,4 +1,5 @@
 require 'math'
+require 'roslua'
 
 function tableConcat(t1, t2)
     for i = 1, #t2 do
@@ -27,7 +28,8 @@ function ros_publishing(inInts, inFloats, inString, inBuffer)
     res = sim.invertMatrix(trans)
     linvel = sim.multiplyVector(trans, linvel)
 
-    outDvl = { '/sim/dvl', 'geometry_msgs/TwistStamped', 'header',
+    topicNamesSpec = roslua.get_msgspec("custom_msgs.msg/TopicNames")
+    outDvl = { topicNamesSpec.sim_dvl, 'geometry_msgs/TwistStamped', 'header',
                "twist.linear.x", "twist.linear.y", "twist.linear.z",
                "twist.angular.x", "twist.angular.y", "twist.angular.z" }
 
@@ -35,7 +37,7 @@ function ros_publishing(inInts, inFloats, inString, inBuffer)
     outDvlData = tableConcat(outDvlData, linvel)
     outDvlData = tableConcat(outDvlData, angvel)
 
-    outPose = { '/sim/pose', 'geometry_msgs/PoseStamped', 'header',
+    outPose = { topicNamesSpec.sim_pose, 'geometry_msgs/PoseStamped', 'header',
                 "pose.position.x", "pose.position.y", "pose.position.z",
                 "pose.orientation.x", "pose.orientation.y", "pose.orientation.z", "pose.orientation.w" }
 
@@ -43,10 +45,10 @@ function ros_publishing(inInts, inFloats, inString, inBuffer)
     outPoseData = tableConcat(outPoseData, pos)
     outPoseData = tableConcat(outPoseData, quat)
 
-    outArray = { '/sim/test_array', 'std_msgs/Float32MultiArray', 'data:14,13,151,12' }
+    outArray = { topicNamesSpec.sim_test_array, 'std_msgs/Float32MultiArray', 'data:14,13,151,12' }
     outArrayData = { -1, -1, ARRAY_FLAG }
 
-    outImu = { '/sim/imu', 'sensor_msgs/Imu', "header",
+    outImu = { topicNamesSpec.sim_imu, 'sensor_msgs/Imu', "header",
                "orientation.x", "orientation.y", "orientation.z", "orientation.w",
                "orientation_covariance:0,0,0,0,0,0,0,0,0",
                "angular_velocity.x", "angular_velocity.y", "angular_velocity.z",
@@ -62,7 +64,7 @@ function ros_publishing(inInts, inFloats, inString, inBuffer)
     outImuData = tableConcat(outImuData, accel)
     outImuData = tableConcat(outImuData, { ARRAY_FLAG })
 
-    outObj = { '/sim/object_points', 'std_msgs/Float32MultiArray' }
+    outObj = { topicNamesSpec.sim_object_points', 'std_msgs/Float32MultiArray' }
     outObj[3] = tableToCommString(getObjectPoints())
     outObjData = { -1, -1, ARRAY_FLAG }
 

--- a/landside/catkin_ws/src/simulation/scripts/simulation_republisher.py
+++ b/landside/catkin_ws/src/simulation/scripts/simulation_republisher.py
@@ -5,19 +5,20 @@ import numpy as np
 from sensor_msgs.msg import Imu
 from std_msgs.msg import Float32MultiArray
 from nav_msgs.msg import Odometry
+from custom_msgs.msg import TopicNames
 from custom_msgs.msg import ThrusterSpeeds
 from geometry_msgs.msg import TwistStamped
 
 
 class SimulationRepublisher():
-    SIM_TWIST_TOPIC = 'sim/dvl'  # TwistStamped message
-    SIM_IMU_TOPIC = 'sim/imu'  # Imu message
-    SIM_POSE_TOPIC = 'sim/pose'  # PoseStamped message
-    SENSOR_FUSION_ODOM_TOPIC = 'sensors/dvl/odom'
-    SENSOR_FUSION_IMU_TOPIC = 'sensors/imu/imu'
+    SIM_TWIST_TOPIC = TopicNames.sim_dvl  # TwistStamped message
+    SIM_IMU_TOPIC = TopicNames.sim_imu  # Imu message
+    SIM_POSE_TOPIC = TopicNames.sim_pose  # PoseStamped message
+    SENSOR_FUSION_ODOM_TOPIC = TopicNames.sensors_dvl_odom
+    SENSOR_FUSION_IMU_TOPIC = TopicNames.sensors_imu_imu
 
-    SIM_MOVE_TOPIC = '/sim/move'
-    ROBOT_MOVE_TOPIC = '/offboard/thruster_speeds'
+    SIM_MOVE_TOPIC = TopicNames.sim_move
+    ROBOT_MOVE_TOPIC = TopicNames.offboard_thruster_speeds
 
     def __init__(self):
         rospy.init_node('simulation_republisher')

--- a/landside/catkin_ws/src/simulation/scripts/squareCommand.py
+++ b/landside/catkin_ws/src/simulation/scripts/squareCommand.py
@@ -2,9 +2,10 @@
 
 import rospy
 from std_msgs.msg import Float32MultiArray
+from custom_msgs.msg import TopicNames
 
 if __name__ == "__main__":
-    pub = rospy.Publisher("/sim/move", Float32MultiArray, queue_size=10)
+    pub = rospy.Publisher(TopicNames.sim_move, Float32MultiArray, queue_size=10)
     rospy.init_node("sim_move_square")
 
     # Initialize direction vectors

--- a/onboard/catkin_ws/src/avt_camera/scripts/mono_camera.py
+++ b/onboard/catkin_ws/src/avt_camera/scripts/mono_camera.py
@@ -3,6 +3,7 @@
 from pymba import *  # noqa
 import rospy
 from sensor_msgs.msg import Image, CameraInfo
+from custom_msgs.msg import TopicNames
 from camera import Camera
 
 
@@ -15,8 +16,8 @@ class MonoCamera:
         camera_name = rospy.get_param('~camera', 'camera')
         camera_id = rospy.get_param('~camera_id', None)
 
-        image_topic = '/camera/{}/image_raw'.format(camera_name)
-        info_topic = '/camera/{}/camera_info'.format(camera_name)
+        image_topic = TopicNames.camera_image_raw.format(camera_name)
+        info_topic = TopicNames.camera_camera_info.format(camera_name)
 
         img_pub = rospy.Publisher(image_topic, Image, queue_size=10)
         info_pub = rospy.Publisher(info_topic, CameraInfo, queue_size=10)

--- a/onboard/catkin_ws/src/avt_camera/scripts/synchronized_cameras.py
+++ b/onboard/catkin_ws/src/avt_camera/scripts/synchronized_cameras.py
@@ -3,6 +3,7 @@
 from pymba import *  # noqa
 import rospy
 from sensor_msgs.msg import Image, CameraInfo
+from custom_msgs.msg import TopicNames
 from camera import Camera
 
 
@@ -16,8 +17,8 @@ class SynchronizedCameras:
         cam_ids = rospy.get_param('~camera_id', dict.fromkeys(cam_name))
         self._cameras = []
         for cam in cam_name:
-            image_topic = '/camera/{}/image_raw'.format(cam)
-            info_topic = '/camera/{}/camera_info'.format(cam)
+            image_topic = TopicNames.camera_image_raw.format(cam)
+            info_topic = TopicNames.camera_camera_info.format(cam)
             img_pub = rospy.Publisher(image_topic, Image, queue_size=10)
             info_pub = rospy.Publisher(info_topic, CameraInfo, queue_size=10)
             self._cameras.append(Camera(img_pub, info_pub, cam, cam_ids[cam]))

--- a/onboard/catkin_ws/src/controls/scripts/controls_utils.py
+++ b/onboard/catkin_ws/src/controls/scripts/controls_utils.py
@@ -1,41 +1,40 @@
 from tf.transformations import euler_from_quaternion, quaternion_multiply, quaternion_conjugate
 from geometry_msgs.msg import Vector3Stamped, Twist, PoseStamped
-
+from custom_msgs.msg import TopicNames
 
 def get_axes():
     return ['x', 'y', 'z', 'roll', 'pitch', 'yaw']
 
 
 def get_pose_topic(axis):
-    return '/controls/state/pose/' + axis
-
+    return TopicNames.controls_state_pose.format(axis)
 
 def get_twist_topic(axis):
-    return '/controls/state/twist/' + axis
+    return TopicNames.controls_state_twist.format(axis)
 
 
 def get_vel_topic(axis):
-    return 'controls/' + axis + '_vel/setpoint'
+    return TopicNames.controls_vel_setpoint.format(axis)
 
 
 def get_pid_topic(axis):
-    return 'controls/' + axis + '_pos/setpoint'
+    return TopicNames.controls_pos_setpoint.format(axis)
 
 
 def get_pos_pid_enable(axis):
-    return 'controls/enable/' + axis + '_pos'
+    return TopicNames.controls_enable_pos.format(axis)
 
 
 def get_vel_pid_enable(axis):
-    return 'controls/enable/' + axis + '_vel'
+    return TopicNames.controls_enable_vel.format(axis)
 
 
 def get_power_topic(axis):
-    return '/controls/power/' + axis
+    return TopicNames.controls_power.format(axis)
 
 
 def get_controls_move_topic(axis):
-    return '/control_effort/' + axis
+    return TopicNames.control_effort.format(axis)
 
 
 def parse_pose(pose):

--- a/onboard/catkin_ws/src/controls/scripts/desired_state.py
+++ b/onboard/catkin_ws/src/controls/scripts/desired_state.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import rospy
+from custom_msgs.msg import TopicNames
 from geometry_msgs.msg import Pose, Twist
 from std_msgs.msg import Float64, Bool
 import controls_utils as utils
@@ -16,9 +17,9 @@ class bcolors:
 
 
 class DesiredStateHandler:
-    DESIRED_TWIST_TOPIC = 'controls/desired_twist'
-    DESIRED_POSE_TOPIC = 'controls/desired_pose'
-    DESIRED_POWER_TOPIC = 'controls/desired_power'
+    DESIRED_TWIST_TOPIC = TopicNames.controls_desired_twist
+    DESIRED_POSE_TOPIC = TopicNames.controls_desired_pose
+    DESIRED_POWER_TOPIC = TopicNames.controls_desired_power
 
     REFRESH_HZ = 10  # for main loop
 

--- a/onboard/catkin_ws/src/controls/scripts/state_republisher.py
+++ b/onboard/catkin_ws/src/controls/scripts/state_republisher.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import rospy
+from custom_msgs.msg import TopicNames
 from std_msgs.msg import Float64
 from nav_msgs.msg import Odometry
 import controls_utils as utils
@@ -8,8 +9,8 @@ from tf import TransformListener
 
 
 class StateRepublisher:
-    STATE_TOPIC = '/state'
-    LOCAL_STATE_TOPIC = '/state_local'
+    STATE_TOPIC = TopicNames.state
+    LOCAL_STATE_TOPIC = TopicNames.state_local
 
     def __init__(self):
         rospy.init_node('state_republisher')

--- a/onboard/catkin_ws/src/controls/scripts/test_state_publisher.py
+++ b/onboard/catkin_ws/src/controls/scripts/test_state_publisher.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
 
 import rospy
+from custom_msgs.msg import TopicNames
 from geometry_msgs.msg import Pose, Twist
 from nav_msgs.msg import Odometry
 
 
 class TestStatePublisher:
-    PUBLISHING_TOPIC_DESIRED_POSE = 'controls/desired_pose'
-    PUBLISHING_TOPIC_DESIRED_TWIST = 'controls/desired_twist'
-    PUBLISHING_TOPIC_CURRENT_STATE = '/state'
-    PUBLISHING_TOPIC_DESIRED_POWER = 'controls/desired_power'
+    PUBLISHING_TOPIC_DESIRED_POSE = TopicNames.controls_desired_pose
+    PUBLISHING_TOPIC_DESIRED_TWIST = TopicNames.controls_desired_twist
+    PUBLISHING_TOPIC_CURRENT_STATE = TopicNames.state
+    PUBLISHING_TOPIC_DESIRED_POWER = TopicNames.controls_desired_power
 
     def __init__(self):
         rospy.init_node('test_state_publisher')

--- a/onboard/catkin_ws/src/controls/scripts/thruster_controls.py
+++ b/onboard/catkin_ws/src/controls/scripts/thruster_controls.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import rospy
 from std_msgs.msg import Float64
+from custom_msgs.msg import TopicNames
 from custom_msgs.msg import ThrusterSpeeds
 import numpy as np
 from thruster_manager import ThrusterManager
@@ -10,7 +11,7 @@ import resource_retriever as rr
 
 
 class ThrusterController:
-    ROBOT_PUB_TOPIC = '/offboard/thruster_speeds'
+    ROBOT_PUB_TOPIC = TopicNames.offboard_thruster_speeds
 
     enabled = False
 

--- a/onboard/catkin_ws/src/cv/scripts/detection.py
+++ b/onboard/catkin_ws/src/cv/scripts/detection.py
@@ -4,6 +4,7 @@ import rospy
 import yaml
 from custom_msgs.msg import CVObject
 from custom_msgs.srv import EnableModel
+from custom_msgs.msg import TopicNames
 from sensor_msgs.msg import Image
 from cv_bridge import CvBridge
 from detecto.core import Model
@@ -24,7 +25,7 @@ class Detector:
             self.models = yaml.load(f)
 
         # The topic that the camera publishes its feed to
-        self.camera_feed_topic = '/camera/{}/image_raw'.format(self.camera)
+        self.camera_feed_topic = TopicNames.camera_image_raw.format(self.camera)
 
         # Toggle model service name
         self.enable_service = 'enable_model_{}'.format(self.camera)

--- a/onboard/catkin_ws/src/cv/scripts/test_images.py
+++ b/onboard/catkin_ws/src/cv/scripts/test_images.py
@@ -5,6 +5,7 @@ import cv2
 import os
 from custom_msgs.srv import EnableModel
 from sensor_msgs.msg import Image
+from custom_msgs.msg import TopicNames
 from cv_bridge import CvBridge
 
 
@@ -13,7 +14,7 @@ class DummyImagePublisher:
 
     NODE_NAME = 'test_images'
     CAMERA = 'left'
-    IMAGE_TOPIC = '/camera/{}/image_raw'.format(CAMERA)
+    IMAGE_TOPIC = TopicNames.camera_image_raw.format(CAMERA)
 
     # Read in the dummy image and other misc. setup work
     def __init__(self):

--- a/onboard/catkin_ws/src/data_pub/scripts/dvl_raw.py
+++ b/onboard/catkin_ws/src/data_pub/scripts/dvl_raw.py
@@ -4,6 +4,7 @@ import serial
 import serial.tools.list_ports as list_ports
 import rospy
 
+from custom_msgs.msg import TopicNames
 from custom_msgs.msg import DVLRaw
 
 
@@ -11,7 +12,7 @@ class DvlRawPublisher:
 
     FTDI_STR = '7006fIP'
     BAUDRATE = 115200
-    TOPIC_NAME = 'sensors/dvl/raw'
+    TOPIC_NAME = TopicNames.sensors_dvl_raw
     NODE_NAME = 'dvl_raw_publisher'
     LINE_DELIM = ','
 

--- a/onboard/catkin_ws/src/data_pub/scripts/dvl_to_odom.py
+++ b/onboard/catkin_ws/src/data_pub/scripts/dvl_to_odom.py
@@ -3,14 +3,15 @@
 import math
 import numpy as np
 import rospy
+from custom_msgs.msg import TopicNames
 from data_pub.msg import DVLRaw
 from geometry_msgs.msg import Point, Pose, Quaternion, Twist, Vector3
 from nav_msgs.msg import Odometry
 from tf.transformations import quaternion_from_euler
 
 NODE_NAME = 'dvl_odom_pub'
-DVL_RAW_TOPIC = 'sensors/dvl/raw'
-DVL_ODOM_TOPIC = 'sensors/dvl/odom'
+DVL_RAW_TOPIC = TopicNames.sensors_dvl_raw
+DVL_ODOM_TOPIC = TopicNames.sensors_dvl_odom
 
 DVL_BAD_STATUS_MSG = 'V'
 

--- a/onboard/catkin_ws/src/data_pub/scripts/imu.py
+++ b/onboard/catkin_ws/src/data_pub/scripts/imu.py
@@ -4,14 +4,15 @@ import rospy
 import serial
 import serial.tools.list_ports as list_ports
 
+from custom_msgs.msg import TopicNames
 from sensor_msgs.msg import Imu, MagneticField
 from tf.transformations import euler_from_quaternion, quaternion_from_euler
 
 
 class IMURawPublisher:
 
-    IMU_DEST_TOPIC_QUAT = 'sensors/imu/imu'
-    IMU_DEST_TOPIC_MAG = 'sensors/imu/mag'
+    IMU_DEST_TOPIC_QUAT = TopicNames.sensors_imu_imu
+    IMU_DEST_TOPIC_MAG = TopicNames.sensors_imu_mag
 
     FTDI_STR = 'FT1WDFQ2'
     BAUDRATE = 115200

--- a/onboard/catkin_ws/src/data_pub/scripts/pressure_converter.py
+++ b/onboard/catkin_ws/src/data_pub/scripts/pressure_converter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import rospy
+from custom_msgs.msg import TopicNames
 from sensor_msgs.msg import FluidPressure
 from std_msgs.msg import Float64
 
@@ -8,8 +9,8 @@ from std_msgs.msg import Float64
 class PressureToDepthConverter:
 
     NODE_NAME = "depth_pub"
-    PRESSURE_SUB_TOPIC = "offboard/pressure"
-    DEPTH_DEST_TOPIC = "sensors/depth"
+    PRESSURE_SUB_TOPIC = TopicNames.offboard_pressure
+    DEPTH_DEST_TOPIC = TopicNames.sensors_depth
 
     DENSITY_WATER = 1000
     ACCEL_GRAVITY = 9.80665

--- a/onboard/catkin_ws/src/offboard_comms/Arduino Sketchbooks/ThrusterServoArduino/ThrusterServoArduino.ino
+++ b/onboard/catkin_ws/src/offboard_comms/Arduino Sketchbooks/ThrusterServoArduino/ThrusterServoArduino.ino
@@ -3,6 +3,7 @@
 #include "MultiplexedBasicESC.h"
 #include "MS5837.h"
 #include <ros.h>
+#include <custom_msgs/TopicNames.h>
 #include <custom_msgs/ThrusterSpeeds.h>
 #include <custom_msgs/ServoAngle.h>
 #include <sensor_msgs/FluidPressure.h>
@@ -43,9 +44,9 @@ sensor_msgs::FluidPressure pressure_msg;
 
 // Sets node handle to have 2 subscribers, 1 publishers, and 128 bytes for input and output buffer
 ros::NodeHandle_<ArduinoHardware,2,1,128,128> nh;
-ros::Subscriber<custom_msgs::ThrusterSpeeds> ts_sub("/offboard/thruster_speeds", &thruster_speeds_callback);
-ros::Subscriber<custom_msgs::ServoAngle> sa_sub("/offboard/servo_angles", &servo_control_callback);
-ros::Publisher pressure_pub("/offboard/pressure", &pressure_msg);
+ros::Subscriber<custom_msgs::ThrusterSpeeds> ts_sub(custom_msgs::TopicNames.offboard_thruster_speeds, &thruster_speeds_callback);
+ros::Subscriber<custom_msgs::ServoAngle> sa_sub(custom_msgs::TopicNames.offboard_servo_angles, &servo_control_callback);
+ros::Publisher pressure_pub(custom_msgs::TopicNames.offboard_pressure, &pressure_msg);
 
 void setup(){
     Serial.begin(BAUD_RATE);

--- a/onboard/catkin_ws/src/task_planning/scripts/task_state.py
+++ b/onboard/catkin_ws/src/task_planning/scripts/task_state.py
@@ -1,17 +1,18 @@
 import rospy
 
+from custom_msgs.msg import TopicNames
 from nav_msgs.msg import Odometry
 from geometry_msgs.msg import Pose, Twist
 from custom_msgs.msg import CVObject
 
 
 class TaskState:
-    STATE_TOPIC = 'state'
-    DESIRED_POSE_TOPIC = 'controls/desired_pose'
-    DESIRED_TWIST_POWER_TOPIC = 'controls/desired_power'
-    DESIRED_TWIST_VELOCITY_TOPIC = 'controls/desired_twist'
-    CV_GATE_DATA_TOPIC = '/cv/_start_gate/left'
-    CV_GATE_TICK_DATA_TOPIC = '/cv/_start_tick/left'
+    STATE_TOPIC = TopicNames.state
+    DESIRED_POSE_TOPIC = TopicNames.controls_desired_pose
+    DESIRED_TWIST_POWER_TOPIC = TopicNames.controls_desired_power
+    DESIRED_TWIST_VELOCITY_TOPIC = TopicNames.controls_desired_twist
+    CV_GATE_DATA_TOPIC = TopicNames.cv_start_gate_left
+    CV_GATE_TICK_DATA_TOPIC = TopicNames.cv_start_tick_left
 
     def __init__(self):
         self.state_listener = rospy.Subscriber(self.STATE_TOPIC, Odometry, self._on_receive_state)


### PR DESCRIPTION
The TopicNames message contains constants with all of the different topic names used across the code base. This means any change in the name of a topic only has to be done in one place.

Closes #268 