### PR TITLE
Automatically launch Saleae Logic with Saleae ROS node

### DIFF
--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -12,7 +12,9 @@ RUN echo "Port 2200" >> /etc/ssh/sshd_config
 
 # Update and install tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libceres-dev unzip zip \
+    xauth pciutils\
+    libceres-dev libusb-dev \
+    unzip zip \
     python-numpy python-scipy python-future  \
     python-six python-dateutil python-skimage \
     python-pywt python-pandas \
@@ -51,7 +53,7 @@ RUN rm -rf camera-driver && \
 RUN wget -O "logic.zip" "http://downloads.saleae.com/logic/1.2.18/Logic+1.2.18+(64-bit).zip" && \
     unzip logic.zip && \
     mv "Logic 1.2.18 (64-bit)" "Logic" && \
-    export PATH="$PATH:$PWD/Logic"
+    ln -s /root/docker-build/Logic/Logic /usr/local/bin/Logic
 
 # Install Arduino CLI for Arduino upload script
 # v0.17.0 is required due to issues with adding libraries in the current version v0.18.0

--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -12,7 +12,7 @@ RUN echo "Port 2200" >> /etc/ssh/sshd_config
 
 # Update and install tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    xauth pciutils\
+    xauth pciutils \
     libceres-dev libusb-dev \
     unzip zip \
     python-numpy python-scipy python-future  \

--- a/onboard/catkin_ws/src/acoustics/README.md
+++ b/onboard/catkin_ws/src/acoustics/README.md
@@ -9,14 +9,14 @@ To launch the main sampling and processing nodes, you can use the launch file pr
 roslaunch acoustics acoustics.launch
 ```
 
+If you are using the saleae (the hardware used to sample the hydrophones), then you will need to have X forwarding enabled (pass in -XY to the ssh command). Note that the graphics process (the saleae Logic application) will persist even after you kill the ROS node.
+
 Refer to the section on the acoustics wrapper structure below for the specific information to send to start processing. To start an action via a GUI (without an action client) refer to this [tutorial](http://wiki.ros.org/actionlib_tutorials/Tutorials/Calling%20Action%20Server%20without%20Action%20Client).
 
-To run the data_sim server that will generate test data, you can use the command:
+To use the data_sim server that will generate test data, instead of hardware sampling with the saleae, you can use the command:
 ```
-rosrun acoustics data_server.py
+roslaunch acoustics acoustics.launch sim:=true
 ```
-
-Refer to the section on structure below for the specific information to send to start the data generation.
 
 ## Structure
 
@@ -26,6 +26,11 @@ This package contains 5 nodes to handle various acoustics tasks: the acoustics w
 The acoustics wrapper node provides an external interface (an action server) to allow client code to easily call all of the steps involved in acoustics processing without providing lower level information such as the sampling frequency or file paths for saved data.
 
 The node itself provides an action server of type `custom_msgs/AcousticsWrapper.action`, which client code will use to call the action. Client code is required to provide the target frequency of the pinger (Robosub provides this depending on what course we are using), and the wrapper server will return the horizontal angle to which the pinger is located at. It will also update the client as to which step is being done via its feedback messages.
+
+To start a GUI for this action using the builtin GUI interface, you may use the command:
+```
+rosrun actionlib axclient.py /acoustics_wrapper
+```
 
 ### Saleae Node
 

--- a/onboard/catkin_ws/src/acoustics/launch/acoustics.launch
+++ b/onboard/catkin_ws/src/acoustics/launch/acoustics.launch
@@ -5,7 +5,7 @@
         <param name="sim" value="$(arg sim)" />
     </node>
     <node pkg="acoustics" name="acoustics_data_generator" type="data_server.py" output="screen" if="$(arg sim)"/>
-    <node pkg="acoustics" name="saleae" type="saleae.py" output="screen" unless="$(arg sim)"/>
+    <node pkg="acoustics" name="saleae" type="saleae_interface.py" output="screen" unless="$(arg sim)"/>
     <node pkg="acoustics" name="acoustics_guesser" type="guess_server.py" output="screen"/>
     <node pkg="acoustics" name="acoustics_processor" type="processing_server.py" output="screen"/>
 

--- a/onboard/catkin_ws/src/acoustics/scripts/acoustics_wrapper.py
+++ b/onboard/catkin_ws/src/acoustics/scripts/acoustics_wrapper.py
@@ -13,7 +13,7 @@ from custom_msgs.msg import AcousticsGuessGoal, AcousticsGuessAction, \
 class AcousticsWrapper:
 
     NODE_NAME = "acoustics_wrapper"
-    ACTION_NAME = "call_guess_processing"
+    ACTION_NAME = "acoustics_wrapper"
 
     SAMPLING_FREQ = {HydrophoneSet.GUESS: 625000, HydrophoneSet.PROCESS: 625000}
     CAPTURE_COUNT = 4

--- a/onboard/catkin_ws/src/acoustics/scripts/saleae_interface.py
+++ b/onboard/catkin_ws/src/acoustics/scripts/saleae_interface.py
@@ -29,7 +29,7 @@ class Saleae:
             os.remove(self.SALEAE_SETTINGS)
         self.saleae = saleae.Saleae(args='-disablepopups -socket')
         rospy.loginfo("Saleae started")
-        
+
         self.server.start()
         rospy.spin()
 

--- a/onboard/catkin_ws/src/acoustics/scripts/saleae_interface.py
+++ b/onboard/catkin_ws/src/acoustics/scripts/saleae_interface.py
@@ -7,14 +7,14 @@ import pandas as pd
 import saleae
 import resource_retriever as rr
 from datetime import datetime
+import os
 
 
 class Saleae:
 
     NODE_NAME = "saleae"
     ACTION_NAME = "call_saleae"
-    IP_ADDRESS = "localhost"
-    PORT = 10429
+    SALEAE_SETTINGS = '/root/docker-build/Logic/Settings/settings.xml'
     CAPTURE_DURATION = 2
     HYDROPHONE_SET = {HydrophoneSet.GUESS: [0, 1, 2, 3], HydrophoneSet.PROCESS: [4, 5, 6, 7]}
     FILE_EXTENSIONS = {HydrophoneSet.GUESS: "_guess", HydrophoneSet.PROCESS: "_processing"}
@@ -22,8 +22,15 @@ class Saleae:
     def __init__(self):
         rospy.init_node(self.NODE_NAME)
         self.server = actionlib.SimpleActionServer(self.ACTION_NAME, SaleaeAction, self.execute, False)
+
+        # Delete the saleae settings file to get around this issue:
+        # https://github.com/saleae/SaleaeSocketApi/issues/14
+        if os.path.exists(self.SALEAE_SETTINGS):
+            os.remove(self.SALEAE_SETTINGS)
+        self.saleae = saleae.Saleae(args='-disablepopups -socket')
+        rospy.loginfo("Saleae started")
+        
         self.server.start()
-        self.saleae = saleae.Saleae(self.IP_ADDRESS, self.PORT)
         rospy.spin()
 
     def publish_feedback(self, stage, total_stages, msg):
@@ -48,13 +55,14 @@ class Saleae:
 
         time_now = datetime.now()
         export_name = "date_" + time_now.strftime("%m_%d_%Y_%H_%M_%S") + self.FILE_EXTENSIONS[goal.hydrophone_set.type]
-        package_path = 'package://acoustics/data/' + export_name + '_({1}).csv'
+        package_path = 'package://acoustics/data/' + export_name + '_({0}).csv'
         save_paths = []
 
         for i in range(goal.capture_count):
             self.publish_feedback(i + 1, goal.capture_count + 1, "Starting capture {}".format(i))
             save_paths.append(package_path.format(i))
             save_path = rr.get_filename(package_path.format(i), use_protocol=False)
+            rospy.loginfo("Path: " + save_path)
             self.saleae.export_data2(save_path, analog_channels=self.HYDROPHONE_SET[goal.hydrophone_set.type])
             self.format_csv(save_path)
 


### PR DESCRIPTION
Closes #272. 

Apparently the python saleae API already launches logic if it is found in the system PATH, so no need to add it to launch file. This symlinks the logic binary to /usr/local/bin to not have to deal with setting the PATH for SSH connections. Also renames saleae.py to saleae_interface.py to avoid a naming conflict with the saleae module. Also updates the readme to be inline with recent changes to acoustics. 

The startup of logic and connection to the saleae has been verified to work on this branch.