### PR TITLE
Allow simulation to be mounted anywhere

### DIFF
--- a/landside/catkin_ws/src/simulation/scripts/runSim.sh
+++ b/landside/catkin_ws/src/simulation/scripts/runSim.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-COPPELIA_SIM_SCRIPT=~/docker-build/coppelia/coppeliaSim.sh
+COPPELIA_SIM_SCRIPT=/root/docker-build/coppelia/coppeliaSim.sh
 SERVER="comm_server_scene.ttt"
 echo "Starting CoppeliaSim"
 
-SERVER_LOCATION=$(find $(rospack find simulation) -name $SERVER | head -1)
+SERVER_LOCATION=$(find "$(rospack find simulation)" -name $SERVER | head -1)
 
 if [ -z "$SERVER_LOCATION" ]
 then

--- a/landside/catkin_ws/src/simulation/scripts/runSim.sh
+++ b/landside/catkin_ws/src/simulation/scripts/runSim.sh
@@ -4,7 +4,7 @@ COPPELIA_SIM_SCRIPT=~/docker-build/coppelia/coppeliaSim.sh
 SERVER="comm_server_scene.ttt"
 echo "Starting CoppeliaSim"
 
-SERVER_LOCATION=$(find /root/dev -name $SERVER | head -1)
+SERVER_LOCATION=$(find $(rospack find simulation) -name $SERVER | head -1)
 
 if [ -z "$SERVER_LOCATION" ]
 then


### PR DESCRIPTION
The CI mounts the code to some nonstandard directory `/github/home/`, which breaks the ROS launch tests since, simulation expects the server to be found under `/root/dev`. This allows for simulation to be mounted anywhere, which should fix the broken build. 