### PR TITLE
Automatically reconnect to disconnected hardware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         filters: |
           docker:
             - 'docker/**'
+            - '.github/workflows/**'
 
   core-docker:
     runs-on: ubuntu-18.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,4 +178,6 @@ jobs:
         run: ./.github/workflows/test_arduino.sh
       - name: Test ROS launchfiles
         shell: bash -elo pipefail {0}
-        run: ./scripts/test-launch.py
+        run: |
+          source ${{ matrix.workspace }}/catkin_ws/devel/setup.bash
+          ./scripts/test-launch.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
         filters: |
           docker:
             - 'docker/**'
-            - '.github/workflows/**'
 
   core-docker:
     runs-on: ubuntu-18.04
@@ -178,7 +177,5 @@ jobs:
         if: matrix.workspace == 'onboard'
         run: ./.github/workflows/test_arduino.sh
       - name: Test ROS launchfiles
-        shell: bash
-        run: |
-          source ${{ matrix.workspace }}/catkin_ws/devel/setup.bash
-          ./scripts/test-launch.py
+        shell: bash -elo pipefail {0}
+        run: ./scripts/test-launch.py

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -21,4 +21,6 @@ jobs:
         run: ./.github/workflows/test_arduino.sh
       - name: Test ROS launchfiles
         shell: bash -elo pipefail {0}
-        run: ./scripts/test-launch.py
+        run: |
+          source ${{ matrix.workspace }}/catkin_ws/devel/setup.bash 
+          ./scripts/test-launch.py

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Test ROS launchfiles
         shell: bash -elo pipefail {0}
         run: |
-          source ${{ matrix.workspace }}/catkin_ws/devel/setup.bash 
+          source ${{ matrix.workspace }}/catkin_ws/devel/setup.bash
           ./scripts/test-launch.py

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -20,7 +20,5 @@ jobs:
         if: matrix.workspace == 'onboard'
         run: ./.github/workflows/test_arduino.sh
       - name: Test ROS launchfiles
-        shell: bash
-        run: |
-          source ${{ matrix.workspace }}/catkin_ws/devel/setup.bash
-          ./scripts/test-launch.py
+        shell: bash -elo pipefail {0}
+        run: ./scripts/test-launch.py

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Use these instructions when running code on the robot itself.
     ```
 1. There, make sure the latest code from this repo is pulled. Then, run the onboard container if it's not already running.
     ```bash
-    docker run -td --privileged --net=host -v /home/robot/robosub-ros:/root/dev/robosub-ros dukerobotics/robosub-ros:onboard
+    docker run -td --privileged --net=host -v /home/robot/robosub-ros:/root/dev/robosub-ros -v /dev/bus/usb:/dev/bus/usb dukerobotics/robosub-ros:onboard
     ```
 1. Clone this repo on your local computer. In the newly-created directory (robosub-ros), run the landside container. If on Windows, use PowerShell.
     ```bash

--- a/onboard/catkin_ws/src/avt_camera/scripts/camera.py
+++ b/onboard/catkin_ws/src/avt_camera/scripts/camera.py
@@ -1,7 +1,6 @@
 from vimba import *  # noqa
 import rospy
 from cv_bridge import CvBridge
-import sys
 from camera_info_manager import CameraInfoManager
 
 

--- a/onboard/catkin_ws/src/avt_camera/scripts/camera.py
+++ b/onboard/catkin_ws/src/avt_camera/scripts/camera.py
@@ -4,9 +4,11 @@ from cv_bridge import CvBridge
 import sys
 from camera_info_manager import CameraInfoManager
 
+
 class bcolors:
     OKGREEN = '\033[92m'
     RESET = '\033[0m'
+
 
 class Camera:
 
@@ -68,7 +70,7 @@ class Camera:
             killswitch.wait()
             try:
                 self._c0.stop_streaming()
-            except:
+            except Exception:
                 pass
 
     def publish_image(self, cam, frame):

--- a/onboard/catkin_ws/src/avt_camera/scripts/mono_camera.py
+++ b/onboard/catkin_ws/src/avt_camera/scripts/mono_camera.py
@@ -14,7 +14,7 @@ class MonoCamera:
     def __init__(self):
         rospy.init_node(self.NODE_NAME, anonymous=True)
         camera_name = rospy.get_param('~camera', 'camera')
-        
+
         self._camera_id = rospy.get_param('~camera_id', None)
 
         image_topic = f'/camera/{camera_name}/image_raw'
@@ -28,14 +28,15 @@ class MonoCamera:
 
     def connection_handler(self, cam, event):
 
-        if event == CameraEvent.Detected and (cam.get_id() == self._camera.get_camera_id() or self._camera.get_camera_id() is None):
+        if event == CameraEvent.Detected and (
+                cam.get_id() == self._camera.get_camera_id() or self._camera.get_camera_id() is None):
             with self._thread_lock:
                 self._thread[1].set()
                 self._thread[0].join()
                 event = threading.Event()
                 self._thread = (threading.Thread(target=self._camera.capture, args=(event,)), event)
                 self._thread[0].start()
-        
+
         elif event == CameraEvent.Missing and cam.get_id() == self._camera.get_camera_id():
             with self._thread_lock:
                 rospy.logerr(f"Lost camera {cam.get_id()}.")
@@ -50,7 +51,7 @@ class MonoCamera:
                 event = threading.Event()
                 self._thread = (threading.Thread(target=self._camera.capture, args=(event,)), event)
                 self._thread[0].start()
-            
+
             vimba.register_camera_change_handler(self.connection_handler)
             rospy.spin()
             vimba.unregister_camera_change_handler(self.connection_handler)

--- a/onboard/catkin_ws/src/avt_camera/scripts/mono_camera.py
+++ b/onboard/catkin_ws/src/avt_camera/scripts/mono_camera.py
@@ -28,7 +28,7 @@ class MonoCamera:
 
     def connection_handler(self, cam, event):
 
-        if event == CameraEvent.Detected and (
+        if event == CameraEvent.Detected and (                                                          # noqa: F405
                 cam.get_id() == self._camera.get_camera_id() or self._camera.get_camera_id() is None):
             with self._thread_lock:
                 self._thread[1].set()
@@ -37,7 +37,7 @@ class MonoCamera:
                 self._thread = (threading.Thread(target=self._camera.capture, args=(event,)), event)
                 self._thread[0].start()
 
-        elif event == CameraEvent.Missing and cam.get_id() == self._camera.get_camera_id():
+        elif event == CameraEvent.Missing and cam.get_id() == self._camera.get_camera_id():             # noqa: F405
             with self._thread_lock:
                 rospy.logerr(f"Lost camera {cam.get_id()}.")
                 self._thread[1].set()

--- a/onboard/catkin_ws/src/avt_camera/scripts/mono_camera.py
+++ b/onboard/catkin_ws/src/avt_camera/scripts/mono_camera.py
@@ -14,24 +14,50 @@ class MonoCamera:
     def __init__(self):
         rospy.init_node(self.NODE_NAME, anonymous=True)
         camera_name = rospy.get_param('~camera', 'camera')
-        camera_id = rospy.get_param('~camera_id', None)
+        
+        self._camera_id = rospy.get_param('~camera_id', None)
 
         image_topic = f'/camera/{camera_name}/image_raw'
         info_topic = f'/camera/{camera_name}/camera_info'
 
         img_pub = rospy.Publisher(image_topic, Image, queue_size=10)
         info_pub = rospy.Publisher(info_topic, CameraInfo, queue_size=10)
-        self._camera = Camera(img_pub, info_pub, rospy.get_name(), camera_id)
+        self._camera = Camera(img_pub, info_pub, rospy.get_name(), self._camera_id)
+        self._thread = None
+        self._thread_lock = threading.Lock()
+
+    def connection_handler(self, cam, event):
+
+        if event == CameraEvent.Detected and (cam.get_id() == self._camera.get_camera_id() or self._camera.get_camera_id() is None):
+            with self._thread_lock:
+                self._thread[1].set()
+                self._thread[0].join()
+                event = threading.Event()
+                self._thread = (threading.Thread(target=self._camera.capture, args=(event,)), event)
+                self._thread[0].start()
+        
+        elif event == CameraEvent.Missing and cam.get_id() == self._camera.get_camera_id():
+            with self._thread_lock:
+                rospy.logerr(f"Lost camera {cam.get_id()}.")
+                self._thread[1].set()
+                self._thread[0].join()
 
     def run(self):
-        with Vimba.get_instance():  # noqa
-            self._camera.initialize_camera()
-            event = threading.Event()
-            thread = threading.Thread(target=self._camera.capture, args=(event,))
-            thread.start()
+        with Vimba.get_instance() as vimba:  # noqa
+            vimba.GeVDiscoveryAllDuration.set(1000)
+            vimba.GeVDiscoveryAllAuto.run()
+            with self._thread_lock:
+                event = threading.Event()
+                self._thread = (threading.Thread(target=self._camera.capture, args=(event,)), event)
+                self._thread[0].start()
+            
+            vimba.register_camera_change_handler(self.connection_handler)
             rospy.spin()
-            event.set()
-            thread.join()
+            vimba.unregister_camera_change_handler(self.connection_handler)
+
+            with self._thread_lock:
+                self._thread[1].set()
+                self._thread[0].join()
 
 
 if __name__ == '__main__':

--- a/onboard/catkin_ws/src/avt_camera/scripts/stereo_camera.py
+++ b/onboard/catkin_ws/src/avt_camera/scripts/stereo_camera.py
@@ -23,7 +23,7 @@ class StereoCamera:
             img_pub = rospy.Publisher(image_topic, Image, queue_size=10)
             info_pub = rospy.Publisher(info_topic, CameraInfo, queue_size=10)
             self._cameras[cam_ids[cam]] = Camera(img_pub, info_pub, cam, cam_ids[cam])
-        
+
         self._thread_lock = threading.Lock()
 
     def connection_handler(self, cam, event):
@@ -33,9 +33,10 @@ class StereoCamera:
                 self._threads[cam.get_id()][1].set()
                 self._threads[cam.get_id()][0].join()
                 event = threading.Event()
-                self._threads[cam.get_id()] = (threading.Thread(target=self._cameras[cam.get_id()].capture, args=(event,)), event)
+                self._threads[cam.get_id()] = (threading.Thread(
+                    target=self._cameras[cam.get_id()].capture, args=(event,)), event)
                 self._threads[cam.get_id()][0].start()
-        
+
         elif event == CameraEvent.Missing and cam.get_id() in self._threads:
             with self._thread_lock:
                 rospy.logerr(f"Lost camera {cam.get_id()}.")

--- a/onboard/catkin_ws/src/avt_camera/scripts/stereo_camera.py
+++ b/onboard/catkin_ws/src/avt_camera/scripts/stereo_camera.py
@@ -15,32 +15,51 @@ class StereoCamera:
         rospy.init_node(self.NODE_NAME, anonymous=True)
         cam_name = rospy.get_param('~camera', ['camera'])
         cam_ids = rospy.get_param('~camera_id', dict.fromkeys(cam_name))
-        self._cameras = []
+        self._cameras = {}
+        self._threads = {}
         for cam in cam_name:
             image_topic = f'/camera/{cam}/image_raw'
             info_topic = f'/camera/{cam}/camera_info'
             img_pub = rospy.Publisher(image_topic, Image, queue_size=10)
             info_pub = rospy.Publisher(info_topic, CameraInfo, queue_size=10)
-            self._cameras.append(Camera(img_pub, info_pub, cam, cam_ids[cam]))
+            self._cameras[cam_ids[cam]] = Camera(img_pub, info_pub, cam, cam_ids[cam])
+        
+        self._thread_lock = threading.Lock()
 
-    def for_each_camera(self, fn):
-        for camera in self._cameras:
-            fn(camera)
+    def connection_handler(self, cam, event):
+
+        if event == CameraEvent.Detected and cam.get_id() in self._threads:
+            with self._thread_lock:
+                self._threads[cam.get_id()][1].set()
+                self._threads[cam.get_id()][0].join()
+                event = threading.Event()
+                self._threads[cam.get_id()] = (threading.Thread(target=self._cameras[cam.get_id()].capture, args=(event,)), event)
+                self._threads[cam.get_id()][0].start()
+        
+        elif event == CameraEvent.Missing and cam.get_id() in self._threads:
+            with self._thread_lock:
+                rospy.logerr(f"Lost camera {cam.get_id()}.")
+                self._threads[cam.get_id()][1].set()
+                self._threads[cam.get_id()][0].join()
 
     def run(self):
-        with Vimba.get_instance():  # noqa
-            self.for_each_camera(lambda camera: camera.initialize_camera())
-            threads = []
-            event = threading.Event()
-            for camera in self._cameras:
-                threads.append(threading.Thread(target=camera.capture, args=(event,)))
+        with Vimba.get_instance() as vimba:  # noqa
+            vimba.GeVDiscoveryAllDuration.set(1000)
+            vimba.GeVDiscoveryAllAuto.run()
+            with self._thread_lock:
+                for id, camera in self._cameras.items():
+                    event = threading.Event()
+                    self._threads[id] = (threading.Thread(target=camera.capture, args=(event,)), event)
+                    self._threads[id][0].start()
 
-            for thread in threads:
-                thread.start()
+            vimba.register_camera_change_handler(self.connection_handler)
             rospy.spin()
-            event.set()
-            for thread in threads:
-                thread.join()
+            vimba.unregister_camera_change_handler(self.connection_handler)
+
+            with self._thread_lock:
+                for thread, event in self._threads.values():
+                    event.set()
+                    thread.join()
 
 
 if __name__ == '__main__':

--- a/onboard/catkin_ws/src/avt_camera/scripts/stereo_camera.py
+++ b/onboard/catkin_ws/src/avt_camera/scripts/stereo_camera.py
@@ -28,7 +28,7 @@ class StereoCamera:
 
     def connection_handler(self, cam, event):
 
-        if event == CameraEvent.Detected and cam.get_id() in self._threads:
+        if event == CameraEvent.Detected and cam.get_id() in self._threads:                 # noqa: F405
             with self._thread_lock:
                 self._threads[cam.get_id()][1].set()
                 self._threads[cam.get_id()][0].join()
@@ -37,7 +37,7 @@ class StereoCamera:
                     target=self._cameras[cam.get_id()].capture, args=(event,)), event)
                 self._threads[cam.get_id()][0].start()
 
-        elif event == CameraEvent.Missing and cam.get_id() in self._threads:
+        elif event == CameraEvent.Missing and cam.get_id() in self._threads:                # noqa: F405
             with self._thread_lock:
                 rospy.logerr(f"Lost camera {cam.get_id()}.")
                 self._threads[cam.get_id()][1].set()

--- a/onboard/catkin_ws/src/data_pub/scripts/dvl_raw.py
+++ b/onboard/catkin_ws/src/data_pub/scripts/dvl_raw.py
@@ -54,7 +54,7 @@ class DvlRawPublisher:
                 line = self._serial.readline().decode('utf-8')
                 if line.strip() and line[0] == ':':
                     self._parse_line(line)
-            except Exception as e:
+            except Exception:
                 rospy.logerr("Error in reading and extracting information. Reconnecting.")
                 rospy.logerr(traceback.format_exc())
                 self._serial.close()

--- a/onboard/catkin_ws/src/data_pub/scripts/dvl_raw.py
+++ b/onboard/catkin_ws/src/data_pub/scripts/dvl_raw.py
@@ -3,6 +3,7 @@
 import serial
 import serial.tools.list_ports as list_ports
 import rospy
+import traceback
 
 from custom_msgs.msg import DVLRaw
 
@@ -32,9 +33,7 @@ class DvlRawPublisher:
             'BD': self._parse_BD
         }
 
-    def run(self):
-        rospy.init_node(self.NODE_NAME)
-
+    def connect(self):
         while self._serial_port is None and not rospy.is_shutdown():
             try:
                 self._serial_port = next(list_ports.grep(self.FTDI_STR)).device
@@ -43,13 +42,25 @@ class DvlRawPublisher:
                                              bytesize=serial.EIGHTBITS, parity=serial.PARITY_NONE,
                                              stopbits=serial.STOPBITS_ONE)
             except StopIteration:
-                rospy.logerr("DVL not found, trying again in 1 second.")
-                rospy.sleep(1)
+                rospy.logerr("DVL not found, trying again in 0.1 seconds.")
+                rospy.sleep(0.1)
+
+    def run(self):
+        rospy.init_node(self.NODE_NAME)
+        self.connect()
 
         while not rospy.is_shutdown():
-            line = self._serial.readline()
-            if line.strip() and line[0] == ':':
-                self._parse_line(line)
+            try:
+                line = self._serial.readline().decode('utf-8')
+                if line.strip() and line[0] == ':':
+                    self._parse_line(line)
+            except Exception as e:
+                rospy.logerr("Error in reading and extracting information. Reconnecting.")
+                rospy.logerr(traceback.format_exc())
+                self._serial.close()
+                self._serial = None
+                self._serial_port = None
+                self.connect()
 
     def _parse_line(self, line):
         data_type = line[1:3]

--- a/onboard/catkin_ws/src/data_pub/scripts/imu.py
+++ b/onboard/catkin_ws/src/data_pub/scripts/imu.py
@@ -3,6 +3,7 @@
 import rospy
 import serial
 import serial.tools.list_ports as list_ports
+import traceback
 
 from sensor_msgs.msg import Imu, MagneticField
 from tf.transformations import euler_from_quaternion, quaternion_from_euler
@@ -16,7 +17,7 @@ class IMURawPublisher:
     FTDI_STR = 'FT1WDFQ2'
     BAUDRATE = 115200
     NODE_NAME = 'imu_pub'
-    LINE_DELIM = ','
+    LINE_DELIM = b','
 
     def __init__(self):
         self._pub_imu = rospy.Publisher(self.IMU_DEST_TOPIC_QUAT, Imu, queue_size=50)
@@ -28,9 +29,7 @@ class IMURawPublisher:
         self._serial_port = None
         self._serial = None
 
-    def run(self):
-        rospy.init_node(self.NODE_NAME)
-
+    def connect(self):
         while self._serial_port is None and not rospy.is_shutdown():
             try:
                 self._serial_port = next(list_ports.grep(self.FTDI_STR)).device
@@ -39,19 +38,29 @@ class IMURawPublisher:
                                              bytesize=serial.EIGHTBITS, parity=serial.PARITY_NONE,
                                              stopbits=serial.STOPBITS_ONE)
             except StopIteration:
-                rospy.logerr("IMU not found, trying again in 1 second.")
-                rospy.sleep(1)
+                rospy.logerr("IMU not found, trying again in 0.1 seconds.")
+                rospy.sleep(0.1)
 
+    def run(self):
+        rospy.init_node(self.NODE_NAME)
+        self.connect()
         while not rospy.is_shutdown():
-            line = self._serial.read_until()
-            items = self._extract_line(line)  # array of line
-            if items[0] == "$VNQMR":
-                rospy.loginfo(line)
-                self._parse_orient(items)
-                self._parse_accel(items)
-                self._parse_angvel(items)
-                self._parse_mag(items)
-                self._publish_current_msg()
+            try:
+                line = self._serial.read_until()
+                items = self._extract_line(line)
+                if items[0] == b"$VNQMR":
+                    self._parse_orient(items)
+                    self._parse_accel(items)
+                    self._parse_angvel(items)
+                    self._parse_mag(items)
+                    self._publish_current_msg()
+            except Exception as e:
+                rospy.logerr("Error in reading and extracting information. Reconnecting.")
+                rospy.logerr(traceback.format_exc())
+                self._serial.close()
+                self._serial = None
+                self._serial_port = None
+                self.connect()
 
     def _extract_line(self, line):
         return line.split(self.LINE_DELIM)

--- a/onboard/catkin_ws/src/data_pub/scripts/imu.py
+++ b/onboard/catkin_ws/src/data_pub/scripts/imu.py
@@ -54,7 +54,7 @@ class IMURawPublisher:
                     self._parse_angvel(items)
                     self._parse_mag(items)
                     self._publish_current_msg()
-            except Exception as e:
+            except Exception:
                 rospy.logerr("Error in reading and extracting information. Reconnecting.")
                 rospy.logerr(traceback.format_exc())
                 self._serial.close()

--- a/onboard/catkin_ws/src/offboard_comms/scripts/port_finder.sh
+++ b/onboard/catkin_ws/src/offboard_comms/scripts/port_finder.sh
@@ -3,6 +3,7 @@
 sudo dmesg | \
 grep tty | \
 sed -n -e 's/^.* ch341-uart converter now attached to \([^ ]*\).*/\1/p' | \
+tail -n 1 | \
 sed -n -e 's/^/\/dev\//p' | \
 tr -d '\n' | \
 cat

--- a/scripts/test-launch.py
+++ b/scripts/test-launch.py
@@ -6,10 +6,7 @@ import os
 import sys
 import psutil
 
-IGNORE_LIST = [
-    'avt_camera/launch/cameras.launch',
-    'avt_camera/launch/stereo_camera.launch',
-]
+IGNORE_LIST = []
 BLOCK_LIST = [
     'cv/launch/cv.launch',
     'joystick/launch/pub_joy.launch',


### PR DESCRIPTION
Closes #280 
Closes #284 

- Camera code has been modified to use the vimba handler to register when cameras are disconnected and reconnected. This has been fully tested (and works really well).
- Saleae is fixed via mounting `/dev/bus/usb` (we might want to just mount the entire `/dev` folder for all devices).
- IMU+DVL code has been updated by catching the exception, closing and reopening the connection. Currently, it is not very well tested, and requires the IMU+DVL to be plugged in when the container is started, but that's ok - we can't access it to unplug it anyways (since its inside the capsule). I believe mounting `/dev` will fix that, but that can be tested later. The code has also been updated to fix some Python 3 errors relating to bytes vs str.
- Arduino port finder script has been fixed by only looking at the last port connected.