### PR TITLE
Automate artifact deletion

### DIFF
--- a/.github/workflows/delete-artifacts.yml
+++ b/.github/workflows/delete-artifacts.yml
@@ -10,10 +10,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Cleanup artifacts
-        uses: geekyeggo/delete-artifact@v1
+      - name: Cleanup old artifacts
+        uses: c-hive/gha-remove-artifacts@v1
         with:
-          name: |
-            onboard
-            landside
-          failOnError: false
+          age: '1 day'


### PR DESCRIPTION
Current delete-artifacts workflow doesn't work, because geekyeggo/delete-artifact only targets artifacts within the workflow run itself. Updated workflow to use [gha-remove-artifacts](c-hive/gha-remove-artifacts@v1), which removes *all* artifacts older than a certain age (1-day in this case). We can configure artifact deletion directly using GitHub's settings, but that solution would delete both build logs and artifacts every day.