### PR TITLE
Migrate CI to docker buildx 

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
+      - name: Save image
+        run: |
+          docker save ${IMAGE_NAME} | gzip > ${FILE_NAME}
+      - name: Create artifact from image
+        uses: actions/upload-artifact@v2
+        with:
+          name: core
+          path: ${{ env.FILE_NAME }}
 
   onboard-docker:
     runs-on: ubuntu-22.04
@@ -70,6 +78,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ needs.check-comment.outputs.sha }}
+      - name: Get core image
+        uses: actions/download-artifact@v2
+        with:
+          name: core
+          path: core_im
+      - name: Load core image
+        run: |
+          docker load < ./core_im/${CORE_FILE_NAME}
+          rm -rf core_im
       - name: Setup environment and build docker image
         run: ./.github/workflows/build.sh
       - name: Save onboard image
@@ -92,6 +109,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ needs.check-comment.outputs.sha }}
+      - name: Get core image
+        uses: actions/download-artifact@v2
+        with:
+          name: core
+          path: core_im
+      - name: Load core image
+        run: |
+          docker load < ./core_im/amd64-core.tar.gz
+          rm -rf core_im
       - name: Setup environment and build docker image
         run: |
           cd docker/${SERVICE_NAME}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -50,14 +50,6 @@ jobs:
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
-      - name: Save image
-        run: |
-          docker save ${IMAGE_NAME} | gzip > ${FILE_NAME}
-      - name: Create artifact from image
-        uses: actions/upload-artifact@v2
-        with:
-          name: core
-          path: ${{ env.FILE_NAME }}
 
   onboard-docker:
     runs-on: ubuntu-22.04
@@ -78,15 +70,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ needs.check-comment.outputs.sha }}
-      - name: Get core image
-        uses: actions/download-artifact@v2
-        with:
-          name: core
-          path: core_im
-      - name: Load core image
-        run: |
-          docker load < ./core_im/${CORE_FILE_NAME}
-          rm -rf core_im
       - name: Setup environment and build docker image
         run: ./.github/workflows/build.sh
       - name: Save onboard image
@@ -109,15 +92,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ needs.check-comment.outputs.sha }}
-      - name: Get core image
-        uses: actions/download-artifact@v2
-        with:
-          name: core
-          path: core_im
-      - name: Load core image
-        run: |
-          docker load < ./core_im/amd64-core.tar.gz
-          rm -rf core_im
       - name: Setup environment and build docker image
         run: |
           cd docker/${SERVICE_NAME}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-comment:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     outputs:
       triggered: ${{ github.event.issue.pull_request && github.event.comment.body == '/build-artifacts'}}
       sha: ${{ steps.sha.outputs.result }}
@@ -29,7 +29,7 @@ jobs:
         ref: ${{ steps.sha.outputs.result }}
 
   core-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: check-comment
     if: ${{ needs.check-comment.outputs.triggered == 'true' }}
     strategy:
@@ -60,7 +60,7 @@ jobs:
           path: ${{ env.FILE_NAME }}
 
   onboard-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: [check-comment, core-docker]
     strategy:
       matrix:
@@ -99,7 +99,7 @@ jobs:
           path: ${{ env.ONBOARD_FILE_NAME }}
 
   landside-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: [check-comment, core-docker]
     env:
       IMAGE_NAME: dukerobotics/robosub-ros:landside
@@ -132,7 +132,7 @@ jobs:
           path: amd64-landside.tar.gz
 
   cleanup-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: [check-comment, onboard-docker, landside-docker]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -11,5 +11,4 @@ cd docker/"${SERVICE_NAME}"
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 docker buildx create --name multiarch --driver docker-container --use --bootstrap
 docker buildx inspect --bootstrap
-docker buildx build --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg TARGETPLATFORM="${TARGETPLATFORM}" --build-arg CUDA="${CUDA}" --platform="${TARGETPLATFORM}" --load -t"${IMAGE_NAME}" .
-docker images
+docker buildx build --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg TARGETPLATFORM="${TARGETPLATFORM}" --build-arg CUDA="${CUDA}" --platform="${TARGETPLATFORM}" --cache-to=type=gha --cache-from=type=gha --load -t"${IMAGE_NAME}" .

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -2,14 +2,9 @@
 
 set -ex
 
-# Use experimental Docker
-sudo apt-get update
 sudo systemctl restart docker
 
 # Build image
 cd docker/"${SERVICE_NAME}"
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-docker buildx create --name multiarch --driver docker-container --use --bootstrap
-docker buildx inspect --bootstrap
 docker buildx build --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg TARGETPLATFORM="${TARGETPLATFORM}" --build-arg CUDA="${CUDA}" --platform="${TARGETPLATFORM}" --load -t"${IMAGE_NAME}" .
-docker images

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -11,4 +11,5 @@ cd docker/"${SERVICE_NAME}"
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 docker buildx create --name multiarch --driver docker-container --use --bootstrap
 docker buildx inspect --bootstrap
-docker buildx build --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg TARGETPLATFORM="${TARGETPLATFORM}" --build-arg CUDA="${CUDA}" --platform="${TARGETPLATFORM}" --cache-to=type=gha --cache-from=type=gha --load -t"${IMAGE_NAME}" .
+docker buildx build --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg TARGETPLATFORM="${TARGETPLATFORM}" --build-arg CUDA="${CUDA}" --platform="${TARGETPLATFORM}" --load -t"${IMAGE_NAME}" .
+docker images

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -2,22 +2,14 @@
 
 set -ex
 
-sudo apt-get update
-sudo apt-get remove docker docker-engine docker.io containerd runc
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
-sudo apt-get update
-sudo apt-get install docker-ce=5:19.03.15~3-0~ubuntu-bionic docker-ce-cli=5:19.03.15~3-0~ubuntu-bionic containerd.io
-
 # Use experimental Docker
-sudo jq -n '{experimental: true}' | sudo tee /etc/docker/daemon.json > /dev/null
+sudo apt-get update
 sudo systemctl restart docker
-
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 # Build image
 cd docker/"${SERVICE_NAME}"
-docker build --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg TARGETPLATFORM="${TARGETPLATFORM}" --build-arg CUDA="${CUDA}" --platform "${TARGETPLATFORM}" -t "${IMAGE_NAME}" .
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker buildx create --name multiarch --driver docker-container --use --bootstrap
+docker buildx inspect --bootstrap
+docker buildx build --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg TARGETPLATFORM="${TARGETPLATFORM}" --build-arg CUDA="${CUDA}" --platform="${TARGETPLATFORM}" --load -t"${IMAGE_NAME}" .
+docker images

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-sudo systemctl restart docker
-
-# Build image
 cd docker/"${SERVICE_NAME}"
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-docker buildx build --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg TARGETPLATFORM="${TARGETPLATFORM}" --build-arg CUDA="${CUDA}" --platform="${TARGETPLATFORM}" --load -t"${IMAGE_NAME}" .
+docker buildx build --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg TARGETPLATFORM="${TARGETPLATFORM}" --build-arg CUDA="${CUDA}" --platform="${TARGETPLATFORM}" --load -t "${IMAGE_NAME}" .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
     steps:
@@ -25,7 +25,7 @@ jobs:
             - '.github/workflows/**'
 
   core-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: check-docker
     if: needs.check-docker.outputs.docker == 'true'
     strategy:
@@ -59,7 +59,7 @@ jobs:
           path: ${{ env.FILE_NAME }}
 
   onboard-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: core-docker
     strategy:
       matrix:
@@ -104,7 +104,7 @@ jobs:
           docker push ${IMAGE_NAME}
 
   push-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: [onboard-docker, landside-docker]
     steps:
       - uses: actions/checkout@v2
@@ -117,7 +117,7 @@ jobs:
           docker buildx imagetools create --tag dukerobotics/robosub-ros:onboard dukerobotics/robosub-ros:onboard-amd64 dukerobotics/robosub-ros:onboard-arm64
   
   cleanup-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: [check-docker, push-docker]
     if: always() && (needs.check-docker.outputs.docker == 'true')
     steps:
@@ -128,7 +128,7 @@ jobs:
           name: core
 
   landside-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: core-docker
     env:
       IMAGE_NAME: dukerobotics/robosub-ros:landside
@@ -162,7 +162,7 @@ jobs:
           docker push ${IMAGE_NAME}
 
   build-without-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: check-docker
     if: needs.check-docker.outputs.docker == 'false'
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,14 @@ jobs:
         run: |
           echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
           docker push ${IMAGE_NAME}
+      - name: Save image
+        run: |
+          docker save ${IMAGE_NAME} | gzip > ${FILE_NAME}
+      - name: Create artifact from image
+        uses: actions/upload-artifact@v2
+        with:
+          name: core
+          path: ${{ env.FILE_NAME }}
 
   onboard-docker:
     runs-on: ubuntu-22.04
@@ -66,6 +74,15 @@ jobs:
       CUDA: ${{ matrix.arch == 'arm64'  }}
     steps:
       - uses: actions/checkout@v2
+      - name: Get core image
+        uses: actions/download-artifact@v2
+        with:
+          name: core
+          path: core_im
+      - name: Load core image
+        run: |
+          docker load < ./core_im/${FILE_NAME}
+          rm -rf core_im
       - name: Setup environment and build docker image
         run: ./.github/workflows/build.sh
       - name: Start containers
@@ -119,6 +136,15 @@ jobs:
       SERVICE_NAME: landside
     steps:
       - uses: actions/checkout@v2
+      - name: Get core image
+        uses: actions/download-artifact@v2
+        with:
+          name: core
+          path: core_im
+      - name: Load core image
+        run: |
+          docker load < ./core_im/amd64-core.tar.gz
+          rm -rf core_im
       - name: Setup environment and build docker image
         run: |
           cd docker/${SERVICE_NAME}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,14 +49,6 @@ jobs:
         run: |
           echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
           docker push ${IMAGE_NAME}
-      - name: Save image
-        run: |
-          docker save ${IMAGE_NAME} | gzip > ${FILE_NAME}
-      - name: Create artifact from image
-        uses: actions/upload-artifact@v2
-        with:
-          name: core
-          path: ${{ env.FILE_NAME }}
 
   onboard-docker:
     runs-on: ubuntu-22.04
@@ -74,15 +66,6 @@ jobs:
       CUDA: ${{ matrix.arch == 'arm64'  }}
     steps:
       - uses: actions/checkout@v2
-      - name: Get core image
-        uses: actions/download-artifact@v2
-        with:
-          name: core
-          path: core_im
-      - name: Load core image
-        run: |
-          docker load < ./core_im/${FILE_NAME}
-          rm -rf core_im
       - name: Setup environment and build docker image
         run: ./.github/workflows/build.sh
       - name: Start containers
@@ -136,15 +119,6 @@ jobs:
       SERVICE_NAME: landside
     steps:
       - uses: actions/checkout@v2
-      - name: Get core image
-        uses: actions/download-artifact@v2
-        with:
-          name: core
-          path: core_im
-      - name: Load core image
-        run: |
-          docker load < ./core_im/amd64-core.tar.gz
-          rm -rf core_im
       - name: Setup environment and build docker image
         run: |
           cd docker/${SERVICE_NAME}

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         workspace: [onboard, landside]

--- a/.github/workflows/delete-artifacts.yml
+++ b/.github/workflows/delete-artifacts.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cleanup-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Cleanup old artifacts

--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -2,10 +2,6 @@
 
 set -ex
 
-# Install buildx
-mkdir -p ~/.docker/cli-plugins
-wget -O ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
-chmod a+x ~/.docker/cli-plugins/docker-buildx
 docker buildx create --name robobuilder --driver docker-container --use
 docker buildx inspect --bootstrap
 docker buildx ls

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -10,10 +10,6 @@ WORKDIR $WORKDIR
 
 ### Basic Setup ###
 
-# Workaround for https://github.com/osrf/docker_images/issues/535
-# Remove this when that is fixed
-RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-
 # Update and install tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-server xvfb \


### PR DESCRIPTION
Closes #291 

Update CI to run on latest ubuntu image (22.04) and migrate build workflows to docker buildx. Buildx migration by itself slightly improved core and onboard build speeds (~1 min). Also uses [cache-to and cache-from](https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-from) to save images to GitHub's cache so that we can skip the saving/loading steps. This cuts down build times a little more, but adds a dependency on the GitHub cache. In the bigger picture, this only saves ~10% of build time, so we can revert back if it isn't worth it.