### PR TITLE
Skip builds on issue comments

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -7,8 +7,8 @@ on:
 jobs:
   check-comment:
     runs-on: ubuntu-22.04
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/build-artifacts'}}
     outputs:
-      triggered: ${{ github.event.issue.pull_request && github.event.comment.body == '/build-artifacts'}}
       sha: ${{ steps.sha.outputs.result }}
     steps:
     - name: Get PR SHA
@@ -31,7 +31,6 @@ jobs:
   core-docker:
     runs-on: ubuntu-22.04
     needs: check-comment
-    if: ${{ needs.check-comment.outputs.triggered == 'true' }}
     strategy:
       matrix:
         arch: [arm64, amd64]


### PR DESCRIPTION
Skips the check-comment stage of the build-artifacts workflow on all non-PR comments and comments that don't include the trigger. This way we don't start a failing workflow every time we leave a comment on an issue.