### PR TITLE
Transform listener usage improvements

### DIFF
--- a/onboard/catkin_ws/src/controls/scripts/test_state_publisher.py
+++ b/onboard/catkin_ws/src/controls/scripts/test_state_publisher.py
@@ -6,7 +6,6 @@ from std_msgs.msg import Float64
 from nav_msgs.msg import Odometry
 import controls_utils
 from tf import TransformListener
-from time import sleep
 
 
 class TestStatePublisher:
@@ -32,7 +31,7 @@ class TestStatePublisher:
         self.current_yaw = 100.0
         self.MOVE_OFFSET_CONSTANT_ANGULAR = 0.2
 
-        sleep(1)
+        self.listener.waitForTransform('odom', 'base_link', rospy.Time(), rospy.Duration(10))
 
         self._pub_desired_pose = rospy.Publisher(self.PUBLISHING_TOPIC_DESIRED_POSE, Pose, queue_size=3)
         self._pub_desired_twist = rospy.Publisher(self.PUBLISHING_TOPIC_DESIRED_TWIST, Twist, queue_size=3)

--- a/onboard/catkin_ws/src/task_planning/scripts/gate_task.py
+++ b/onboard/catkin_ws/src/task_planning/scripts/gate_task.py
@@ -8,7 +8,7 @@ import smach
 import rospy
 from task import Task
 from move_tasks import MoveToPoseLocalTask, MoveToPoseGlobalTask
-from tf import TransformListener
+import tf
 from time import sleep
 
 
@@ -34,9 +34,13 @@ INPUT FROM CMD copper or bootlegger, direction to rotate, time to wait and movin
 def main():
     rospy.init_node('gate_task')
 
+    listener = tf.TransformListener()
+
     # needs direction to work
-    sm = create_simple_gate_task_sm()
-    sleep(2)
+    sm = create_simple_gate_task_sm(listener)
+
+    listener.waitForTransform('odom', 'base_link', rospy.Time(), rospy.Duration(10))
+
     # Execute SMACH plan
     sm.execute()
 
@@ -44,15 +48,14 @@ def main():
 # Check if we actually want this later
 
 
-def create_gate_task_sm():
-    return create_gate_task_sm_DEFUNCT(1)
+def create_gate_task_sm(listener):
+    return create_gate_task_sm_DEFUNCT(listener, 1)
 
 # Rotate direction is +1 or -1 depending on how we should rotate
 
 
-def create_gate_task_sm_DEFUNCT(rotate_direction):
+def create_gate_task_sm_DEFUNCT(listener, rotate_direction):
     sm = smach.StateMachine(outcomes=['succeeded', 'failed'])
-    listener = TransformListener()
     gate_euler_position = [0, 0, 0, 0, 0, 0]
     image_name = "bootleggerbuoy"
     with sm:
@@ -81,9 +84,8 @@ def create_gate_task_sm_DEFUNCT(rotate_direction):
 # SIMPLE version below
 
 
-def create_simple_gate_task_sm(rotate_direction, image_name):
+def create_simple_gate_task_sm(listener, rotate_direction, image_name):
     sm = smach.StateMachine(outcomes=['succeeded', 'failed'])
-    listener = TransformListener()
     global_object_position = [0, 0, 0, 0, 0, 0]
     with sm:
         smach.StateMachine.add('DIVE_TO_GATE', MoveToPoseGlobalTask(0, 0, -2, 0, 0, 0, listener),
@@ -110,9 +112,8 @@ def create_simple_gate_task_sm(rotate_direction, image_name):
     return sm
 
 
-def create_simplest_gate_task_sm():
+def create_simplest_gate_task_sm(listener):
     sm = smach.StateMachine(outcomes=['succeeded', 'failed'])
-    listener = TransformListener()
     with sm:
         smach.StateMachine.add('MOVE_1', MoveToPoseLocalTask(2.5, 0, -2, 0, 0, 0, listener),
                                transitions={

--- a/onboard/catkin_ws/src/task_planning/scripts/gate_task.py
+++ b/onboard/catkin_ws/src/task_planning/scripts/gate_task.py
@@ -9,7 +9,6 @@ import rospy
 from task import Task
 from move_tasks import MoveToPoseLocalTask, MoveToPoseGlobalTask
 import tf
-from time import sleep
 
 
 SIDE_THRESHOLD = 0.1  # means gate post is within 1 tenth of the side of the frame

--- a/onboard/catkin_ws/src/task_planning/scripts/move_tasks.py
+++ b/onboard/catkin_ws/src/task_planning/scripts/move_tasks.py
@@ -75,8 +75,7 @@ class MoveToPoseLocalTask(MoveToPoseGlobalTask):
         self.listener = listener
 
     def run(self, userdata):
-        if 'base_link' in self.listener.getFrameStrings():
-            self.desired_pose = task_utils.transform_pose(self.listener, 'base_link', 'odom', self.desired_pose)
+        self.desired_pose = task_utils.transform_pose(self.listener, 'base_link', 'odom', self.desired_pose)
         return super(MoveToPoseLocalTask, self).run(userdata)
 
 


### PR DESCRIPTION
This changes task planning to use a single TransformListener created in `task_runner.py`, rather than creating a TransformListener in each state machine creation method. We also now properly wait for transforms to become available (for up to 15 seconds before timing out), rather than arbitrarily sleeping for 2 seconds.