### PR TITLE
Bump action versions to node 16

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -13,18 +13,18 @@ jobs:
     steps:
     - name: Get PR SHA
       id: sha
-      uses: actions/github-script@v4
+      uses: actions/github-script@v6
       with:
         result-encoding: string
         script: |
           const { owner, repo, number } = context.issue;
-          const pr = await github.pulls.get({
+          const pr = await github.rest.pulls.get({
             owner,
             repo,
             pull_number: number,
           });
           return pr.data.head.sha          
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ steps.sha.outputs.result }}
 
@@ -43,7 +43,7 @@ jobs:
       FILE_NAME: '${{ matrix.arch }}-core.tar.gz'
       CUDA: ${{ matrix.arch == 'arm64'  }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ needs.check-comment.outputs.sha }}
       - name: Setup environment and build
@@ -53,7 +53,7 @@ jobs:
         run: |
           docker save ${IMAGE_NAME} | gzip > ${FILE_NAME}
       - name: Create artifact from image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: core
           path: ${{ env.FILE_NAME }}
@@ -74,11 +74,11 @@ jobs:
       ONBOARD_FILE_NAME: '${{ matrix.arch }}-onboard.tar.gz'
       CUDA: ${{ matrix.arch == 'arm64'  }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ needs.check-comment.outputs.sha }}
       - name: Get core image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: core
           path: core_im
@@ -92,7 +92,7 @@ jobs:
         run: |
           docker save ${IMAGE_NAME} | gzip > ${ONBOARD_FILE_NAME}
       - name: Create artifact from image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: onboard
           path: ${{ env.ONBOARD_FILE_NAME }}
@@ -105,11 +105,11 @@ jobs:
       BASE_IMAGE: dukerobotics/robosub-ros:core-amd64
       SERVICE_NAME: landside
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ needs.check-comment.outputs.sha }}
       - name: Get core image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: core
           path: core_im
@@ -125,7 +125,7 @@ jobs:
         run: |
           docker save ${IMAGE_NAME} | gzip > amd64-landside.tar.gz
       - name: Create artifact from image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: landside
           path: amd64-landside.tar.gz
@@ -134,10 +134,10 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [check-comment, onboard-docker, landside-docker]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ needs.check-comment.outputs.sha }}
       - name: Cleanup artifacts
-        uses: geekyeggo/delete-artifact@v1
+        uses: geekyeggo/delete-artifact@v2
         with:
           name: core

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check if docker directory has changed
       uses: dorny/paths-filter@v2.2.1
       id: filter
@@ -40,7 +40,7 @@ jobs:
       FILE_NAME: '${{ matrix.arch }}-core.tar.gz'
       CUDA: ${{ matrix.arch == 'arm64'  }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
@@ -53,7 +53,7 @@ jobs:
         run: |
           docker save ${IMAGE_NAME} | gzip > ${FILE_NAME}
       - name: Create artifact from image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: core
           path: ${{ env.FILE_NAME }}
@@ -73,9 +73,9 @@ jobs:
       FILE_NAME: '${{ matrix.arch }}-core.tar.gz'
       CUDA: ${{ matrix.arch == 'arm64'  }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get core image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: core
           path: core_im
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [onboard-docker, landside-docker]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Push images to latest on dockerhub
         if: github.event_name == 'push'
         run: |
@@ -121,9 +121,9 @@ jobs:
     needs: [check-docker, push-docker]
     if: always() && (needs.check-docker.outputs.docker == 'true')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cleanup artifacts
-        uses: geekyeggo/delete-artifact@v1
+        uses: geekyeggo/delete-artifact@v2
         with:
           name: core
 
@@ -135,9 +135,9 @@ jobs:
       BASE_IMAGE: dukerobotics/robosub-ros:core-amd64
       SERVICE_NAME: landside
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get core image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: core
           path: core_im
@@ -171,7 +171,7 @@ jobs:
       fail-fast: false
     container: dukerobotics/robosub-ros:${{ matrix.workspace }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Test build
         run: ./build.sh
       - name: Test Arduino build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Check if docker directory has changed
-      uses: dorny/paths-filter@v2.2.1
+      uses: dorny/paths-filter@v2.11.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -13,7 +13,7 @@ jobs:
         workspace: [onboard, landside]
     container: dukerobotics/robosub-ros:${{ matrix.workspace }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3s
       - name: Test build
         run: ./build.sh
       - name: Test Arduino build

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -13,7 +13,7 @@ jobs:
         workspace: [onboard, landside]
     container: dukerobotics/robosub-ros:${{ matrix.workspace }}
     steps:
-      - uses: actions/checkout@v3s
+      - uses: actions/checkout@v3
       - name: Test build
         run: ./build.sh
       - name: Test Arduino build

--- a/.github/workflows/delete-artifacts.yml
+++ b/.github/workflows/delete-artifacts.yml
@@ -9,7 +9,7 @@ jobs:
   cleanup-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cleanup old artifacts
         uses: c-hive/gha-remove-artifacts@v1
         with:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,7 +10,7 @@ jobs:
     name: Lint Code Base
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Lint Code Base
         uses: github/super-linter@v3.17.0
         env:


### PR DESCRIPTION
Closes #376

Updating to the latest version of each GitHub action in our CI. The only API that changed was `actions/github-script`.