### PR TITLE
Change controls to use ROS Actions

### DIFF
--- a/core/catkin_ws/src/custom_msgs/CMakeLists.txt
+++ b/core/catkin_ws/src/custom_msgs/CMakeLists.txt
@@ -37,6 +37,9 @@ add_action_files(
   AcousticsWrapper.action
   Saleae.action
   AcousticsData.action
+  ControlsDesiredPose.action
+  ControlsDesiredTwist.action
+  ControlsDesiredPower.action
 )
 
 generate_messages(

--- a/core/catkin_ws/src/custom_msgs/action/ControlsDesiredPose.action
+++ b/core/catkin_ws/src/custom_msgs/action/ControlsDesiredPose.action
@@ -1,0 +1,4 @@
+geometry_msgs/Pose pose 
+---
+
+---

--- a/core/catkin_ws/src/custom_msgs/action/ControlsDesiredPower.action
+++ b/core/catkin_ws/src/custom_msgs/action/ControlsDesiredPower.action
@@ -1,0 +1,4 @@
+geometry_msgs/Twist power 
+---
+
+---

--- a/core/catkin_ws/src/custom_msgs/action/ControlsDesiredTwist.action
+++ b/core/catkin_ws/src/custom_msgs/action/ControlsDesiredTwist.action
@@ -1,0 +1,4 @@
+geometry_msgs/Twist twist 
+---
+
+---

--- a/landside/catkin_ws/src/gui/src/gui/controls_widget.py
+++ b/landside/catkin_ws/src/gui/src/gui/controls_widget.py
@@ -251,10 +251,10 @@ class ControlsWidget(QWidget):
             for k in range(3):
                 if ppid[i][k] > 1:
                     ppid_scal[k] = 10**(math.floor(math.log10(ppid[i][k])) + 1)
-                    ppid[i][k] = ppid[i][k]/ppid_scal[k]
+                    ppid[i][k] = ppid[i][k] / ppid_scal[k]
                 if vpid[i][k] > 1:
                     vpid_scal[k] = 10**(math.floor(math.log10(vpid[i][k])) + 1)
-                    vpid[i][k] = vpid[i][k]/vpid_scal[k]
+                    vpid[i][k] = vpid[i][k] / vpid_scal[k]
 
             pos_client.update_configuration({'Kp': ppid[i][0],
                                              'Ki': ppid[i][1],

--- a/onboard/catkin_ws/src/controls/README.md
+++ b/onboard/catkin_ws/src/controls/README.md
@@ -7,7 +7,7 @@ Thruster information is read from `*.config` files, which are written in YAML. T
 
 `controls.launch` takes in a `sim` argument to indicate whether it is running in the simulation or on the robot.
 
-Only the most recently updated Desired State Topic will be used in movement. Therefore any updates will override the current movement of the robot. Controls will warn you if more than one Desired State Topic is being published to at any given time to prevent such issues. If Controls stops receiving Desired State messages at a high enough rate (at the moment, 10 Hz), it will warn you and will output zero power for safety purposes.
+Only the most recently sent goal received by a Desired State Action Server will be used in movement. Therefore any new goals will preempt existing goals for any of the three control actions and override the current movement of the robot.
 
 The controls algorithm will output all 0's unless it is enabled with a call to rosservice as detailed in the setup. Sending the disable call to the service acts as a software emergency stop that cuts off all power to the thrusters.
 
@@ -61,25 +61,29 @@ roslaunch controls controls.launch sim:=true
 `test_state_publisher.py` is where we specify the desired state of the robot. Alternatively, you can publish to any of the desired state topics directly using your own code. The second command launches the entire controls node in simulation mode.
 
 
-## Topics
+## Interface
 
 ### Listening
 
-Desired State Topics:
+Desired State Action Servers:
 
   - ```controls/desired_pose```
-    + A point and quaternion representing the robot's desired global xyz position and rpy orientation.
-    + Type: geometry_msgs/Pose
+    + Type: ```custom_msgs/ControlsDesiredPoseAction```
+    + Goal: ```custom_msgs/ControlsDesiredPoseGoal```
+      - Contains a ```geometry_msgs/Pose```
+      - Pose has fields for a point and quaternion representing the robot's desired global xyz position and rpy orientation.
 
   - ```controls/desired_twist```
-    + A twist with representing the robot's desired local linear and angular velocities.
-    + Type: geometry_msgs/Twist
+    + Type: ```custom_msgs/ControlsDesiredTwistAction```
+    + Goal: ```custom_msgs/ControlsDesiredTwistGoal```
+      - Contains a ```geometry_msgs/Twist``` which has fields for the robot's desired local linear and angular velocities.
 
   - ```controls/desired_power```
-    + A twist with values [-1,1] corresponding to effort the robot should exert in each local axis. 1 is full speed in a positive direction, -1 is full speed in the negative direction.
-    + This option stabilizes velocity on all axes with values of 0. It is mainly for use with joysticks (velocity control should be used in almost every other case).
-    + For instance, a `desired_power` message of [1, 0, -0.5, 0, 0, 0], the robot will move full speed in the +x direction, half speed in the -z direction, and stabilize velocities on all other axes.
-    + Type: geometry_msgs/Twist
+    + Type: ```custom_msgs/ControlsDesiredPowerAction```
+    + Goal: ```custom_msgs/ControlsDesiredPowerGoal```
+      - Contains a ```geometry_msgs/Twist``` with values [-1,1] corresponding to effort the robot should exert in each local axis. 1 is full speed in a positive direction, -1 is full speed in the negative direction.
+      - This option stabilizes velocity on all axes with values of 0. It is mainly for use with joysticks (velocity control should be used in almost every other case).
+      - For instance, a `desired_power` goal of [1, 0, -0.5, 0, 0, 0], the robot will move full speed in the +x direction, half speed in the -z direction, and stabilize velocities on all other axes.
 
 Current State Topics:
 

--- a/onboard/catkin_ws/src/controls/scripts/desired_state.py
+++ b/onboard/catkin_ws/src/controls/scripts/desired_state.py
@@ -6,7 +6,7 @@ import controls_utils as utils
 from tf import TransformListener
 from pid_manager import PIDManager
 
-from custom_msgs.msg import ControlsDesiredPose, ControlsDesiredTwist, ControlsDesiredPower
+from custom_msgs.msg import ControlsDesiredPoseAction, ControlsDesiredTwistAction, ControlsDesiredPowerAction
 
 class bcolors:
     BOLD = '\033[1m'
@@ -42,9 +42,9 @@ class DesiredStateHandler:
         self.listener = TransformListener()
         self.pid_manager = PIDManager()
 
-        self.pose_server = actionlib.SimpleActionServer(self.DESIRED_POSE_ACTION, ControlsDesiredPose, self._on_pose_received, False)
-        self.twist_server = actionlib.SimpleActionServer(self.DESIRED_TWIST_ACTION, ControlsDesiredTwist, self._on_twist_received, False)
-        self.power_server = actionlib.SimpleActionServer(self.DESIRED_POWER_ACTION, ControlsDesiredPower, self._on_power_received, False)
+        self.pose_server = actionlib.SimpleActionServer(self.DESIRED_POSE_ACTION, ControlsDesiredPoseAction, self._on_pose_received, False)
+        self.twist_server = actionlib.SimpleActionServer(self.DESIRED_TWIST_ACTION, ControlsDesiredTwistAction, self._on_twist_received, False)
+        self.power_server = actionlib.SimpleActionServer(self.DESIRED_POWER_ACTION, ControlsDesiredPowerAction, self._on_power_received, False)
         
         self.pose_server.start()
         self.twist_server.start()

--- a/onboard/catkin_ws/src/controls/scripts/test_state_publisher.py
+++ b/onboard/catkin_ws/src/controls/scripts/test_state_publisher.py
@@ -3,7 +3,7 @@
 import rospy
 import actionlib
 from custom_msgs.msg import ControlsDesiredPoseAction, ControlsDesiredTwistAction, ControlsDesiredPowerAction, \
-                            ControlsDesiredPoseGoal, ControlsDesiredTwistGoal, ControlsDesiredPowerGoal
+    ControlsDesiredPoseGoal, ControlsDesiredTwistGoal, ControlsDesiredPowerGoal
 from geometry_msgs.msg import Pose, Twist
 from std_msgs.msg import Float64
 from nav_msgs.msg import Odometry
@@ -105,19 +105,19 @@ class TestStatePublisher:
         self.current_state.header.stamp = rospy.Time()
 
     def publish_desired_pose_global(self):
-        self._desired_pose_client.send_goal(ControlsDesiredPoseGoal(pose = self.desired_pose_global))
+        self._desired_pose_client.send_goal(ControlsDesiredPoseGoal(pose=self.desired_pose_global))
         rospy.spin()
 
     def publish_desired_pose_local(self):
-        self._desired_pose_client.send_goal(ControlsDesiredPoseGoal(pose = self.desired_pose_transformed))
+        self._desired_pose_client.send_goal(ControlsDesiredPoseGoal(pose=self.desired_pose_transformed))
         rospy.spin()
 
     def publish_desired_twist(self):
-        self._desired_twist_client.send_goal(ControlsDesiredTwistGoal(twist = self.desired_twist))
+        self._desired_twist_client.send_goal(ControlsDesiredTwistGoal(twist=self.desired_twist))
         rospy.spin()
 
     def publish_desired_power(self):
-        self._desired_power_client.send_goal(ControlsDesiredPowerGoal(power = self.desired_power))
+        self._desired_power_client.send_goal(ControlsDesiredPowerGoal(power=self.desired_power))
         rospy.spin()
 
     def move_to_pos_and_stop(self, x, y, z):
@@ -133,7 +133,7 @@ class TestStatePublisher:
 
         rate = rospy.Rate(15)
 
-        self._desired_pose_client.send_goal(ControlsDesiredPoseGoal(pose = self.desired_pose_transformed))
+        self._desired_pose_client.send_goal(ControlsDesiredPoseGoal(pose=self.desired_pose_transformed))
 
         delay = 0
         while not rospy.is_shutdown():
@@ -166,7 +166,7 @@ class TestStatePublisher:
 
         rate = rospy.Rate(15)
 
-        self._desired_pose_client.send_goal(ControlsDesiredPoseGoal(pose = self.desired_pose_transformed))
+        self._desired_pose_client.send_goal(ControlsDesiredPoseGoal(pose=self.desired_pose_transformed))
 
         delay = 0
         while not rospy.is_shutdown():
@@ -202,7 +202,7 @@ class TestStatePublisher:
 
         rate = rospy.Rate(15)
 
-        self._desired_pose_client.send_goal(ControlsDesiredPoseGoal(pose = self.desired_pose_transformed))
+        self._desired_pose_client.send_goal(ControlsDesiredPoseGoal(pose=self.desired_pose_transformed))
 
         # DELAY BASED STOPPING PROTOCOL
         # tot = 0

--- a/onboard/catkin_ws/src/controls/scripts/test_state_publisher.py
+++ b/onboard/catkin_ws/src/controls/scripts/test_state_publisher.py
@@ -2,7 +2,8 @@
 
 import rospy
 import actionlib
-from custom_msgs.msg import ControlsDesiredPose, ControlsDesiredTwist, ControlsDesiredPower, ControlsDesiredPoseGoal, ControlsDesiredTwistGoal, ControlsDesiredPowerGoal
+from custom_msgs.msg import ControlsDesiredPoseAction, ControlsDesiredTwistAction, ControlsDesiredPowerAction, \
+                            ControlsDesiredPoseGoal, ControlsDesiredTwistGoal, ControlsDesiredPowerGoal
 from geometry_msgs.msg import Pose, Twist
 from std_msgs.msg import Float64
 from nav_msgs.msg import Odometry
@@ -35,9 +36,9 @@ class TestStatePublisher:
 
         self.listener.waitForTransform('odom', 'base_link', rospy.Time(), rospy.Duration(10))
 
-        self._desired_pose_client = actionlib.SimpleActionClient(self.ACTION_DESIRED_POSE, ControlsDesiredPose)
-        self._desired_twist_client = actionlib.SimpleActionClient(self.ACTION_DESIRED_TWIST, ControlsDesiredTwist)
-        self._desired_power_client = actionlib.SimpleActionClient(self.ACTION_DESIRED_POWER, ControlsDesiredPower)
+        self._desired_pose_client = actionlib.SimpleActionClient(self.ACTION_DESIRED_POSE, ControlsDesiredPoseAction)
+        self._desired_twist_client = actionlib.SimpleActionClient(self.ACTION_DESIRED_TWIST, ControlsDesiredTwistAction)
+        self._desired_power_client = actionlib.SimpleActionClient(self.ACTION_DESIRED_POWER, ControlsDesiredPowerAction)
         self._pub_current_state = rospy.Publisher(self.PUBLISHING_TOPIC_CURRENT_STATE, Odometry, queue_size=3)
 
         self._desired_pose_client.wait_for_server()

--- a/onboard/catkin_ws/src/task_planning/scripts/move_tasks.py
+++ b/onboard/catkin_ws/src/task_planning/scripts/move_tasks.py
@@ -51,7 +51,7 @@ class MoveToPoseGlobalTask(Task):
                 self.publish_desired_pose_global(lastPose)
 
             rate.sleep()
-        
+
         self.task_state.desired_pose_global_client.cancel_goal()
         return "done"
 

--- a/onboard/catkin_ws/src/task_planning/scripts/move_tasks.py
+++ b/onboard/catkin_ws/src/task_planning/scripts/move_tasks.py
@@ -37,13 +37,22 @@ class MoveToPoseGlobalTask(Task):
     def run(self, userdata):
         print("moving to ", self.desired_pose)
         rate = rospy.Rate(15)
+        lastPose = self.getPose()
+        self.publish_desired_pose_global(lastPose)
         while not(
             self.state and task_utils.stopped_at_pose(
                 self.state.pose.pose,
                 self.getPose(),
                 self.state.twist.twist)):
-            self.publish_desired_pose_global(self.getPose())
+            # Resend the goal pose only if the target pose has changed
+            newPose = self.getPose()
+            if not task_utils.at_pose(lastPose, newPose, 0.0001, 0.0001):
+                lastPose = newPose
+                self.publish_desired_pose_global(lastPose)
+
             rate.sleep()
+        
+        self.task_state.desired_pose_global_client.cancel_goal()
         return "done"
 
     def getPose(self):
@@ -124,11 +133,12 @@ class AllocateVelocityLocalForeverTask(Task):
     def run(self, userdata):
         # rospy.loginfo("publishing desired twist...")
         rate = rospy.Rate(15)
+        self.publish_desired_twist(self.desired_twist)
         while True:
             if self.preempt_requested():
+                self.task_state.desired_twist_velocity_client.cancel_goal()
                 self.service_preempt()
                 return 'preempted'
-            self.publish_desired_twist(self.desired_twist)
             rate.sleep()
 
 

--- a/onboard/catkin_ws/src/task_planning/scripts/task.py
+++ b/onboard/catkin_ws/src/task_planning/scripts/task.py
@@ -1,4 +1,5 @@
 from task_state import TaskState
+from custom_msgs.msg import ControlsDesiredPoseGoal, ControlsDesiredTwistGoal, ControlsDesiredPowerGoal
 import dependency_injector.providers as providers
 import smach
 
@@ -43,10 +44,10 @@ class Task(smach.State):
         return self.run(userdata)
 
     def publish_desired_pose_global(self, pose):
-        self.task_state.desired_pose_global_publisher.publish(pose)
+        self.task_state.desired_pose_global_client.send_goal(ControlsDesiredPoseGoal(pose = pose))
 
     def publish_desired_power(self, twist_power):
-        self.task_state.desired_twist_power_publisher.publish(twist_power)
+        self.task_state.desired_twist_power_client.send_goal(ControlsDesiredPowerGoal(power = twist_power))
 
     def publish_desired_twist(self, twist_velocity):
-        self.task_state.desired_twist_velocity_publisher.publish(twist_velocity)
+        self.task_state.desired_twist_velocity_client.send_goal(ControlsDesiredTwistGoal(twist = twist_velocity))

--- a/onboard/catkin_ws/src/task_planning/scripts/task.py
+++ b/onboard/catkin_ws/src/task_planning/scripts/task.py
@@ -44,10 +44,10 @@ class Task(smach.State):
         return self.run(userdata)
 
     def publish_desired_pose_global(self, pose):
-        self.task_state.desired_pose_global_client.send_goal(ControlsDesiredPoseGoal(pose = pose))
+        self.task_state.desired_pose_global_client.send_goal(ControlsDesiredPoseGoal(pose=pose))
 
     def publish_desired_power(self, twist_power):
-        self.task_state.desired_twist_power_client.send_goal(ControlsDesiredPowerGoal(power = twist_power))
+        self.task_state.desired_twist_power_client.send_goal(ControlsDesiredPowerGoal(power=twist_power))
 
     def publish_desired_twist(self, twist_velocity):
-        self.task_state.desired_twist_velocity_client.send_goal(ControlsDesiredTwistGoal(twist = twist_velocity))
+        self.task_state.desired_twist_velocity_client.send_goal(ControlsDesiredTwistGoal(twist=twist_velocity))

--- a/onboard/catkin_ws/src/task_planning/scripts/task_state.py
+++ b/onboard/catkin_ws/src/task_planning/scripts/task_state.py
@@ -1,15 +1,16 @@
 import rospy
+import actionlib
 
 from nav_msgs.msg import Odometry
 from geometry_msgs.msg import Pose, Twist
-from custom_msgs.msg import CVObject
+from custom_msgs.msg import CVObject, ControlsDesiredPoseAction, ControlsDesiredTwistAction, ControlsDesiredPowerAction
 
 
 class TaskState:
     STATE_TOPIC = '/state'
-    DESIRED_POSE_TOPIC = 'controls/desired_pose'
-    DESIRED_TWIST_POWER_TOPIC = 'controls/desired_power'
-    DESIRED_TWIST_VELOCITY_TOPIC = 'controls/desired_twist'
+    DESIRED_POSE_ACTION = 'controls/desired_pose'
+    DESIRED_TWIST_POWER_ACTION = 'controls/desired_power'
+    DESIRED_TWIST_VELOCITY_ACTION = 'controls/desired_twist'
     CV_DATA_TOPICS = ["/cv/simulation/bin/left",
                       "/cv/simulation/bootleggerbuoy/left",
                       "/cv/simulation/gate/left",
@@ -22,9 +23,9 @@ class TaskState:
 
     def __init__(self):
         self.state_listener = rospy.Subscriber(self.STATE_TOPIC, Odometry, self._on_receive_state)
-        self.desired_pose_global_publisher = rospy.Publisher(self.DESIRED_POSE_TOPIC, Pose, queue_size=5)
-        self.desired_twist_power_publisher = rospy.Publisher(self.DESIRED_TWIST_POWER_TOPIC, Twist, queue_size=5)
-        self.desired_twist_velocity_publisher = rospy.Publisher(self.DESIRED_TWIST_VELOCITY_TOPIC, Twist, queue_size=5)
+        self.desired_pose_global_client = actionlib.SimpleActionClient(self.DESIRED_POSE_ACTION, ControlsDesiredPoseAction)
+        self.desired_twist_velocity_client = actionlib.SimpleActionClient(self.DESIRED_TWIST_VELOCITY_ACTION, ControlsDesiredTwistAction)
+        self.desired_twist_power_client = actionlib.SimpleActionClient(self.DESIRED_TWIST_POWER_ACTION, ControlsDesiredPowerAction)
         self.state = None
 
         self.cv_data = {}
@@ -32,6 +33,10 @@ class TaskState:
             name = topic.replace("/left", "").split("/")[-1]
             self.cv_data[name] = None
             rospy.Subscriber(topic, CVObject, self._on_receive_cv_data, name)
+
+        self.desired_pose_global_client.wait_for_server()
+        self.desired_twist_velocity_client.wait_for_server()
+        self.desired_twist_power_client.wait_for_server()
 
     def _on_receive_state(self, state):
         """Receive the state, update initial_state if it is empty

--- a/onboard/catkin_ws/src/task_planning/scripts/task_state.py
+++ b/onboard/catkin_ws/src/task_planning/scripts/task_state.py
@@ -2,7 +2,6 @@ import rospy
 import actionlib
 
 from nav_msgs.msg import Odometry
-from geometry_msgs.msg import Pose, Twist
 from custom_msgs.msg import CVObject, ControlsDesiredPoseAction, ControlsDesiredTwistAction, ControlsDesiredPowerAction
 
 

--- a/onboard/catkin_ws/src/task_planning/scripts/task_state.py
+++ b/onboard/catkin_ws/src/task_planning/scripts/task_state.py
@@ -23,9 +23,12 @@ class TaskState:
 
     def __init__(self):
         self.state_listener = rospy.Subscriber(self.STATE_TOPIC, Odometry, self._on_receive_state)
-        self.desired_pose_global_client = actionlib.SimpleActionClient(self.DESIRED_POSE_ACTION, ControlsDesiredPoseAction)
-        self.desired_twist_velocity_client = actionlib.SimpleActionClient(self.DESIRED_TWIST_VELOCITY_ACTION, ControlsDesiredTwistAction)
-        self.desired_twist_power_client = actionlib.SimpleActionClient(self.DESIRED_TWIST_POWER_ACTION, ControlsDesiredPowerAction)
+        self.desired_pose_global_client = actionlib.SimpleActionClient(
+            self.DESIRED_POSE_ACTION, ControlsDesiredPoseAction)
+        self.desired_twist_velocity_client = actionlib.SimpleActionClient(
+            self.DESIRED_TWIST_VELOCITY_ACTION, ControlsDesiredTwistAction)
+        self.desired_twist_power_client = actionlib.SimpleActionClient(
+            self.DESIRED_TWIST_POWER_ACTION, ControlsDesiredPowerAction)
         self.state = None
 
         self.cv_data = {}


### PR DESCRIPTION
This changes controls so that instead of having to publish to specific topics at a fixed rate, we use actions to send "goals" which run until pre-empted by another goal or canceled manually. The relevant task-planning changes that come as part of this PR have been done hastily, due to our plans to refactor some of our task planning system next.

Closes #351