### PR TITLE
Camera custom autodiscovery

### DIFF
--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -53,7 +53,8 @@ RUN pip3 install --no-cache-dir \
     pyserial dependency-injector \
     gputil saleae \
     bluerobotics-ping \
-    roboflow
+    roboflow \
+    python-nmap
 
 # Install PyTorch and Torchvision
 COPY torch_installer.sh torch_deps/torch_installer.sh

--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -42,7 +42,8 @@ RUN apt-get update && \
     ros-noetic-rosserial-arduino \
     ffmpeg \
     iputils-ping \
-    python3-pandas && \
+    python3-pandas \
+    nmap && \
     apt-get clean && \
     # Clear apt caches to reduce image size
     rm -rf /var/lib/apt/lists/*

--- a/onboard/catkin_ws/src/cv/scripts/depthai_camera_connect.py
+++ b/onboard/catkin_ws/src/cv/scripts/depthai_camera_connect.py
@@ -93,15 +93,13 @@ def connect(pipeline):
 def custom_autodiscovery():
     """
     Scans all IP addresses from 192.168.1.0 to 192.168.1.255 looking for the DepthAI camera's MAC address.
-    If successful, returns the camera's IP address.
-    If not successful, raises RuntimeError
 
-    :return: IP address string
+    :return: DepthAI IP address string
     :raises RuntimeError: if the camera's IP address could not be found
     """
 
     MAC_address = "44:A9:2C:3C:0A:90"  # DepthAI camera MAC address
-    IP_range = "192.168.1.0/24"
+    IP_range = "192.168.1.0/24"  # 192.168.1.0 to 192.168.1.255
 
     nm = nmap.PortScanner()
     scan = nm.scan(hosts=IP_range, arguments='-sP')['scan']


### PR DESCRIPTION
DepthAI’s built-in autodiscovery feature cannot find the camera’s DHCP-assigned IP address. Thus, this pull request adds custom autodiscovery as a third method to connect to the camera in `depthai_camera_connect.py`.

`custom_autodiscovery` scans the IP addresses in the range 192.168.1.0 to 192.168.1.255 looking for the DepthAI Camera MAC address and returns the appropriate IP address if found.