### PR TITLE
System Info Publisher

### DIFF
--- a/onboard/catkin_ws/src/execute/launch/motion.launch
+++ b/onboard/catkin_ws/src/execute/launch/motion.launch
@@ -23,4 +23,6 @@
 
 	<include file="$(find vectornav)/launch/vectornav.launch" />
 
+	<include file="$(find system_utils)/launch/system_pub.launch" />
+
 </launch>

--- a/onboard/catkin_ws/src/system_utils/scripts/system_info_publisher.py
+++ b/onboard/catkin_ws/src/system_utils/scripts/system_info_publisher.py
@@ -17,7 +17,7 @@ class SystemInfoPublisher:
 
     def get_cpu(self):
         self._current_msg.cpu_percent = psutil.cpu_percent(interval=0.5)
-        self._current_msg.cpu_speed = psutil.cpu_freq().current
+        self._current_msg.cpu_speed = psutil.cpu_freq().current if psutil.cpu_freq() else 0
 
     def get_gpu(self):
         GPUs = GPUtil.getGPUs()


### PR DESCRIPTION
Fixed a bug in system info publisher that caused it to crash when run locally (not on robot). Added system info publisher to motion.launch.