### PR TITLE
Scrollable Extensions

### DIFF
--- a/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
+++ b/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
@@ -117,6 +117,8 @@ function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.
 }
 
 export function initCallServicePanel(context: PanelExtensionContext): () => void {
+  context.panelElement.style.overflow = "auto"; // Enable scrolling
+
   const root = createRoot(context.panelElement as HTMLElement);
   root.render(<CallServicePanel context={context} />);
 

--- a/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
+++ b/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
@@ -105,6 +105,8 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
 }
 
 export function initPublishTopicPanel(context: PanelExtensionContext): () => void {
+  context.panelElement.style.overflow = "auto"; // Enable scrolling
+
   const root = createRoot(context.panelElement as HTMLElement);
   root.render(<PublishTopicPanel context={context} />);
 

--- a/foxglove/extensions/sensors-status-panel/src/SensorsStatusPanel.tsx
+++ b/foxglove/extensions/sensors-status-panel/src/SensorsStatusPanel.tsx
@@ -169,6 +169,8 @@ function SensorsStatusPanel({ context }: { context: PanelExtensionContext }): JS
 }
 
 export function initSensorsStatusPanel(context: PanelExtensionContext): () => void {
+  context.panelElement.style.overflow = "auto"; // Enable scrolling
+
   const root = createRoot(context.panelElement as HTMLElement);
   root.render(<SensorsStatusPanel context={context} />);
 

--- a/foxglove/extensions/subscribe-topic-panel/src/SubscribeTopicPanel.tsx
+++ b/foxglove/extensions/subscribe-topic-panel/src/SubscribeTopicPanel.tsx
@@ -104,6 +104,8 @@ function SubscribeTopicPanel({ context }: { context: PanelExtensionContext }): J
 }
 
 export function initSubscribeTopicPanel(context: PanelExtensionContext): () => void {
+  context.panelElement.style.overflow = "auto"; // Enable scrolling
+
   const root = createRoot(context.panelElement as HTMLElement);
   root.render(<SubscribeTopicPanel context={context} />);
 

--- a/foxglove/extensions/system-status-panel/src/SystemStatusPanel.tsx
+++ b/foxglove/extensions/system-status-panel/src/SystemStatusPanel.tsx
@@ -100,6 +100,8 @@ function SystemStatusPanel({ context }: { context: PanelExtensionContext }): JSX
 }
 
 export function initSystemStatusPanel(context: PanelExtensionContext): () => void {
+  context.panelElement.style.overflow = "auto"; // Enable scrolling
+
   const root = createRoot(context.panelElement as HTMLElement);
   root.render(<SystemStatusPanel context={context} />);
 

--- a/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
+++ b/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
@@ -345,6 +345,8 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
 }
 
 export function initThrusterSpeedsPanel(context: PanelExtensionContext): () => void {
+  context.panelElement.style.overflow = "auto"; // Enable scrolling
+
   const root = createRoot(context.panelElement as HTMLElement);
   root.render(<ThrusterSpeedsPanel context={context} />);
 

--- a/foxglove/extensions/toggle-controls-panel/src/ToggleControlsPanel.tsx
+++ b/foxglove/extensions/toggle-controls-panel/src/ToggleControlsPanel.tsx
@@ -85,6 +85,8 @@ function ToggleControlsPanel({ context }: { context: PanelExtensionContext }): J
 }
 
 export function initToggleControlsPanel(context: PanelExtensionContext): () => void {
+  context.panelElement.style.overflow = "auto"; // Enable scrolling
+
   const root = createRoot(context.panelElement as HTMLElement);
   root.render(<ToggleControlsPanel context={context} />);
 

--- a/foxglove/extensions/toggle-joystick-panel/src/ToggleJoystickPanel.tsx
+++ b/foxglove/extensions/toggle-joystick-panel/src/ToggleJoystickPanel.tsx
@@ -344,6 +344,8 @@ function ToggleJoystickPanel({ context }: { context: PanelExtensionContext }): J
 }
 
 export function initToggleJoystickPanel(context: PanelExtensionContext): () => void {
+  context.panelElement.style.overflow = "auto"; // Enable scrolling
+
   const root = createRoot(context.panelElement as HTMLElement);
   root.render(<ToggleJoystickPanel context={context} />);
 


### PR DESCRIPTION
Closes #488.

Inside each `initPanel` method, add the following line at the beginning:
```js
context.panelElement.style.overflow = "auto"; // Enable scrolling
```