### PR TITLE
Foxglove Cleanup

### DIFF
--- a/foxglove/README.md
+++ b/foxglove/README.md
@@ -45,7 +45,6 @@ To uninstall all layouts, use:
 ```bash
 python foxglove.py uninstall -l
 ```
-**Note:** The user must be signed out of Foxglove to uninstall layouts using this CLI. You can still uninstall layouts manually through the app.
 
 For more information, consult the usage guide of `foxglove.py` with the `-h` flag:
 ```bash

--- a/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
+++ b/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
@@ -64,7 +64,7 @@ function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.
       <Box m={1}>
         {context.callService == undefined && (
           <Alert variant="filled" severity="error">
-            Calling services is not supported by this connection
+            Calling services is not supported by this connection.
           </Alert>
         )}
 

--- a/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
+++ b/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
@@ -1,6 +1,6 @@
 import useTheme from "@duke-robotics/theme";
 import { Immutable, PanelExtensionContext, RenderState } from "@foxglove/studio";
-import { Box, ThemeProvider } from "@mui/material";
+import { Box, Button, InputAdornment, TextField, ThemeProvider } from "@mui/material";
 import Alert from "@mui/material/Alert";
 import { JsonViewer } from "@textea/json-viewer";
 import { useEffect, useState } from "react";
@@ -62,45 +62,68 @@ function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.
   return (
     <ThemeProvider theme={theme}>
       <Box m={1}>
-        {context.callService == undefined && (
-          <Alert variant="filled" severity="error">
-            Calling services is not supported by this connection.
-          </Alert>
+        {/* Error messages */}
+        {(context.callService == undefined || state.error != undefined) && (
+          <Box mb={1}>
+            {context.callService == undefined && (
+              <Alert variant="filled" severity="error">
+                Calling services is not supported by this connection.
+              </Alert>
+            )}
+            {state.error != undefined && (
+              <Alert variant="filled" severity="error">
+                {state.error.message}
+              </Alert>
+            )}
+          </Box>
         )}
 
-        <h4>Service Name</h4>
-        <div>
-          <input
-            type="text"
-            placeholder="Enter service name"
-            style={{ width: "100%" }}
-            value={state.serviceName}
-            onChange={(event) => {
-              setState({ ...state, serviceName: event.target.value });
-            }}
-          />
-        </div>
-        <h4>Request</h4>
-        <div>
-          <textarea
-            style={{ width: "100%", minHeight: "3rem" }}
-            value={state.request}
-            onChange={(event) => {
-              setState({ ...state, request: event.target.value });
-            }}
-          />
-        </div>
-        <div>
-          <button
-            disabled={context.callService == undefined || state.serviceName === ""}
-            style={{ width: "100%", minHeight: "2rem" }}
-            onClick={callServiceWithRequest}
-          >
-            {`Call ${state.serviceName}`}
-          </button>
-        </div>
+        {/* Topic Name Input */}
+        <TextField
+          label="Topic Name"
+          type="text"
+          size="small"
+          margin="dense"
+          fullWidth
+          value={state.serviceName}
+          onChange={(event) => {
+            setState((prevState) => ({
+              ...prevState,
+              serviceName: event.target.value,
+            }));
+          }}
+          InputProps={{
+            startAdornment: <InputAdornment position="start">/</InputAdornment>,
+          }}
+        />
 
-        <div>
+        {/* Request Input */}
+        <TextField
+          margin="dense"
+          size="small"
+          multiline
+          label="Request"
+          fullWidth
+          value={state.request}
+          onChange={(event) => {
+            setState((prevState) => ({
+              ...prevState,
+              request: event.target.value,
+            }));
+          }}
+        />
+
+        {/* Publish Once Button */}
+        <Button
+          fullWidth
+          variant="contained"
+          disabled={context.callService == undefined || state.serviceName === ""}
+          onClick={callServiceWithRequest}
+        >
+          {`Call Service`}
+        </Button>
+
+        <Box>
           <h4>Response</h4>
           <JsonViewer
             rootName={false}
@@ -110,7 +133,7 @@ function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.
             enableClipboard={false}
             displayDataTypes={false}
           />
-        </div>
+        </Box>
       </Box>
     </ThemeProvider>
   );

--- a/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
+++ b/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
@@ -17,7 +17,20 @@ type CallServicePanelState = {
 
 function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.Element {
   const [renderDone, setRenderDone] = useState<(() => void) | undefined>();
-  const [state, setState] = useState<CallServicePanelState>({ serviceName: "", request: "{\n\n}" });
+
+  const [state, setState] = useState<CallServicePanelState>(() => {
+    const initialState = context.initialState as CallServicePanelState | undefined;
+
+    return {
+      serviceName: initialState?.serviceName ?? "",
+      request: initialState?.request ?? "{\n\n}",
+    };
+  });
+
+  // Save state upon change
+  useEffect(() => {
+    context.saveState(state);
+  }, [state, context]);
 
   // Update color scheme
   useEffect(() => {

--- a/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
+++ b/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
@@ -17,7 +17,14 @@ type CallServicePanelState = {
 
 function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.Element {
   const [renderDone, setRenderDone] = useState<(() => void) | undefined>();
-  const [state, setState] = useState<CallServicePanelState>({ serviceName: "", request: "{\n\n}" });
+  const [state, setState] = useState<CallServicePanelState>(() => {
+    const initialState = context.initialState as CallServicePanelState;
+    return { serviceName: initialState.serviceName, request: initialState.request };
+  });
+
+  useEffect(() => {
+    context.saveState(state);
+  }, [context, state]);
 
   // Update color scheme
   useEffect(() => {

--- a/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
+++ b/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
@@ -62,6 +62,7 @@ function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.
         }));
       },
       (error) => {
+        // Handle service call errors (e.g., service is not advertised)
         setState((oldState) => ({ ...oldState, error: error as Error }));
       },
     );

--- a/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
+++ b/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
@@ -11,13 +11,13 @@ type CallServicePanelState = {
   serviceName: string;
   request: string;
   response?: unknown;
-  error?: Error | undefined;
+  error?: Error;
   colorScheme?: RenderState["colorScheme"];
 };
 
 function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.Element {
   const [renderDone, setRenderDone] = useState<(() => void) | undefined>();
-  const [state, setState] = useState<CallServicePanelState>({ serviceName: "", request: "{}" });
+  const [state, setState] = useState<CallServicePanelState>({ serviceName: "", request: "{\n\n}" });
 
   // Update color scheme
   useEffect(() => {
@@ -40,7 +40,7 @@ function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.
     }
 
     try {
-      const response = await context.callService(serviceName, JSON.parse(request));
+      const response = await context.callService(`/${serviceName}`, JSON.parse(request));
       JSON.stringify(response); // Attempt serializing the response, to throw an error on failure
       setState((oldState) => ({
         ...oldState,
@@ -78,9 +78,9 @@ function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.
           </Box>
         )}
 
-        {/* Topic Name Input */}
+        {/* Service Name Input */}
         <TextField
-          label="Topic Name"
+          label="Service Name"
           type="text"
           size="small"
           margin="dense"
@@ -113,21 +113,23 @@ function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.
           }}
         />
 
-        {/* Publish Once Button */}
-        <Button
-          fullWidth
-          variant="contained"
-          disabled={context.callService == undefined || state.serviceName === ""}
-          onClick={callServiceWithRequest}
-        >
-          {`Call Service`}
-        </Button>
+        <Box my={1}>
+          {/* Publish Once Button */}
+          <Button
+            fullWidth
+            variant="contained"
+            disabled={context.callService == undefined || state.serviceName === ""}
+            onClick={callServiceWithRequest}
+          >
+            {`Call Service`}
+          </Button>
+        </Box>
 
         <Box>
           <h4>Response</h4>
           <JsonViewer
             rootName={false}
-            value={state.error ? { error: state.error.message } : state.response ?? {}}
+            value={state.response}
             indentWidth={2}
             theme={state.colorScheme}
             enableClipboard={false}

--- a/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
+++ b/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
@@ -1,6 +1,6 @@
 import useTheme from "@duke-robotics/theme";
 import { Immutable, PanelExtensionContext, RenderState } from "@foxglove/studio";
-import { Box, Button, InputAdornment, TextField, ThemeProvider } from "@mui/material";
+import { Box, Button, InputAdornment, TextField, ThemeProvider, Typography } from "@mui/material";
 import Alert from "@mui/material/Alert";
 import { JsonViewer } from "@textea/json-viewer";
 import { useEffect, useState } from "react";
@@ -34,28 +34,24 @@ function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.
   }, [renderDone]);
 
   // Call a service with a given request
-  const callService = async (serviceName: string, request: string) => {
+  const callService = () => {
     if (!context.callService) {
       return;
     }
 
-    try {
-      const response = await context.callService(`/${serviceName}`, JSON.parse(request));
-      JSON.stringify(response); // Attempt serializing the response, to throw an error on failure
-      setState((oldState) => ({
-        ...oldState,
-        response,
-        error: undefined,
-      }));
-    } catch (error) {
-      setState((oldState) => ({ ...oldState, error: error as Error }));
-      console.error(error);
-    }
-  };
-
-  // Close callService with the current state for use in the button
-  const callServiceWithRequest = () => {
-    void callService(state.serviceName, state.request);
+    context.callService(`/${state.serviceName}`, JSON.parse(state.request)).then(
+      (response) => {
+        JSON.stringify(response); // Attempt serializing the response, to throw an error on failure
+        setState((oldState) => ({
+          ...oldState,
+          response,
+          error: undefined,
+        }));
+      },
+      (error) => {
+        setState((oldState) => ({ ...oldState, error: error as Error }));
+      },
+    );
   };
 
   const theme = useTheme();
@@ -114,25 +110,27 @@ function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.
         />
 
         <Box my={1}>
-          {/* Publish Once Button */}
+          {/* Call Service Button */}
           <Button
             fullWidth
             variant="contained"
             disabled={context.callService == undefined || state.serviceName === ""}
-            onClick={callServiceWithRequest}
+            onClick={callService}
           >
             {`Call Service`}
           </Button>
         </Box>
 
         <Box>
-          <h4>Response</h4>
+          <Typography variant="subtitle1" gutterBottom>
+            Response
+          </Typography>
           <JsonViewer
             rootName={false}
             value={state.response}
             indentWidth={2}
             theme={state.colorScheme}
-            enableClipboard={false}
+            enableClipboard={true}
             displayDataTypes={false}
           />
         </Box>

--- a/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
+++ b/foxglove/extensions/call-service-panel/src/CallServicePanel.tsx
@@ -17,14 +17,7 @@ type CallServicePanelState = {
 
 function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.Element {
   const [renderDone, setRenderDone] = useState<(() => void) | undefined>();
-  const [state, setState] = useState<CallServicePanelState>(() => {
-    const initialState = context.initialState as CallServicePanelState;
-    return { serviceName: initialState.serviceName, request: initialState.request };
-  });
-
-  useEffect(() => {
-    context.saveState(state);
-  }, [context, state]);
+  const [state, setState] = useState<CallServicePanelState>({ serviceName: "", request: "{\n\n}" });
 
   // Update color scheme
   useEffect(() => {

--- a/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
+++ b/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
@@ -129,6 +129,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
               margin="dense"
               fullWidth
               value={state.topicName}
+              disabled={state.repeatPublish != null}
               onChange={(event) => {
                 setState((prevState) => ({
                   ...prevState,
@@ -151,6 +152,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
               error={state.invalidRate}
               helperText={state.invalidRate ? "Rate must be positive." : ""}
               defaultValue={state.publishRate}
+              disabled={state.repeatPublish != null}
               onChange={handleRateChange}
               InputProps={{
                 endAdornment: <InputAdornment position="end">Hz</InputAdornment>,
@@ -166,6 +168,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
               fullWidth
               options={Object.keys(allDatatypeMaps)}
               value={state.schemaType}
+              disabled={state.repeatPublish != null}
               onChange={(_, newValue) => {
                 // Don't allow undefined since we need to use schema type as a key to get the schema names
                 setState((prevState) => ({
@@ -182,6 +185,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
               fullWidth
               options={Object.keys(allDatatypeMaps[state.schemaType])}
               value={state.schemaName}
+              disabled={state.repeatPublish != null}
               onChange={(_, newValue) => {
                 setState((prevState) => ({
                   ...prevState,
@@ -201,6 +205,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
           label="Request"
           fullWidth
           value={state.request}
+          disabled={state.repeatPublish != null}
           onChange={(event) => {
             setState((prevState) => ({
               ...prevState,

--- a/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
+++ b/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
@@ -111,7 +111,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
 
         <Grid container spacing={1}>
           <Grid item xs={8}>
-            {/* Topic Input */}
+            {/* Topic Name Input */}
             <TextField
               label="Topic Name"
               type="text"

--- a/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
+++ b/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
@@ -3,7 +3,7 @@ import useTheme from "@duke-robotics/theme";
 import { PanelExtensionContext } from "@foxglove/studio";
 import { Autocomplete, Box, Button, Grid, InputAdornment, TextField, ThemeProvider } from "@mui/material";
 import Alert from "@mui/material/Alert";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 type PublishTopicPanelState = {
@@ -19,14 +19,22 @@ type PublishTopicPanelState = {
 };
 
 function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX.Element {
-  const [state, setState] = useState<PublishTopicPanelState>({
-    topicName: "",
-    request: "{\n\n}",
-    schemaType: "ros1",
-    publishRate: 10,
-    repeatPublish: null,
-    invalidRate: false,
+  const [state, setState] = useState<PublishTopicPanelState>(() => {
+    const initialState = context.initialState as PublishTopicPanelState;
+    return {
+      topicName: initialState.topicName,
+      request: initialState.request,
+      schemaType: initialState.schemaType,
+      schemaName: initialState.schemaName,
+      publishRate: initialState.publishRate,
+      invalidRate: initialState.invalidRate,
+      repeatPublish: null,
+    };
   });
+
+  useEffect(() => {
+    context.saveState(state);
+  }, [context, state]);
 
   // Pubish a request with a given schema to a topic
   const publishTopic = () => {

--- a/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
+++ b/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
@@ -3,7 +3,7 @@ import useTheme from "@duke-robotics/theme";
 import { PanelExtensionContext } from "@foxglove/studio";
 import { Autocomplete, Box, Button, Grid, InputAdornment, TextField, ThemeProvider } from "@mui/material";
 import Alert from "@mui/material/Alert";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { createRoot } from "react-dom/client";
 
 type PublishTopicPanelState = {
@@ -19,22 +19,14 @@ type PublishTopicPanelState = {
 };
 
 function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX.Element {
-  const [state, setState] = useState<PublishTopicPanelState>(() => {
-    const initialState = context.initialState as PublishTopicPanelState;
-    return {
-      topicName: initialState.topicName,
-      request: initialState.request,
-      schemaType: initialState.schemaType,
-      schemaName: initialState.schemaName,
-      publishRate: initialState.publishRate,
-      invalidRate: initialState.invalidRate,
-      repeatPublish: null,
-    };
+  const [state, setState] = useState<PublishTopicPanelState>({
+    topicName: "",
+    request: "{\n\n}",
+    schemaType: "ros1",
+    publishRate: 10,
+    repeatPublish: null,
+    invalidRate: false,
   });
-
-  useEffect(() => {
-    context.saveState(state);
-  }, [context, state]);
 
   // Pubish a request with a given schema to a topic
   const publishTopic = () => {

--- a/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
+++ b/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
@@ -3,7 +3,7 @@ import useTheme from "@duke-robotics/theme";
 import { PanelExtensionContext } from "@foxglove/studio";
 import { Autocomplete, Box, Button, Grid, InputAdornment, TextField, ThemeProvider } from "@mui/material";
 import Alert from "@mui/material/Alert";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 type PublishTopicPanelState = {
@@ -19,14 +19,24 @@ type PublishTopicPanelState = {
 };
 
 function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX.Element {
-  const [state, setState] = useState<PublishTopicPanelState>({
-    topicName: "",
-    request: "{\n\n}",
-    schemaType: "ros1",
-    publishRate: 10,
-    repeatPublish: null,
-    invalidRate: false,
+  const [state, setState] = useState<PublishTopicPanelState>(() => {
+    const initialState = context.initialState as PublishTopicPanelState | undefined;
+
+    return {
+      topicName: initialState?.topicName ?? "",
+      request: initialState?.request ?? "{\n\n}",
+      schemaType: (initialState?.schemaType ?? "ros1") as keyof AllDatatypeMapsType,
+      schemaName: initialState?.schemaName ?? undefined,
+      publishRate: initialState?.publishRate ?? 1,
+      repeatPublish: null,
+      invalidRate: false,
+    };
   });
+
+  // Save state upon change
+  useEffect(() => {
+    context.saveState(state);
+  }, [state, context]);
 
   // Pubish a request with a given schema to a topic
   const publishTopic = () => {

--- a/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
+++ b/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
@@ -48,7 +48,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
     } catch (e) {
       setState((prevState) => ({
         ...prevState,
-        error: e as Error,
+        error: e as Error, // Catch JSON parse errors
       }));
     }
   };
@@ -71,6 +71,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
     }
   };
 
+  // Validate rate input
   const handleRateChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(event.target.value);
 
@@ -110,11 +111,12 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
 
         <Grid container spacing={1}>
           <Grid item xs={8}>
+            {/* Topic Input */}
             <TextField
-              margin="dense"
-              size="small"
-              type="text"
               label="Topic Name"
+              type="text"
+              size="small"
+              margin="dense"
               fullWidth
               value={state.topicName}
               onChange={(event) => {
@@ -129,15 +131,16 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
             />
           </Grid>
           <Grid item xs={4}>
+            {/* Rate Input */}
             <TextField
-              margin="dense"
+              label="Rate"
+              type="number"
               size="small"
+              margin="dense"
+              fullWidth
               error={state.invalidRate}
               helperText={state.invalidRate ? "Rate must be positive." : ""}
-              label="Rate"
               defaultValue={state.publishRate}
-              type="number"
-              fullWidth
               onChange={handleRateChange}
               InputProps={{
                 endAdornment: <InputAdornment position="end">Hz</InputAdornment>,
@@ -148,6 +151,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
 
         <Grid container spacing={1}>
           <Grid item xs={4}>
+            {/* Schema Type Input */}
             <Autocomplete
               fullWidth
               options={Object.keys(allDatatypeMaps)}
@@ -163,6 +167,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
             />
           </Grid>
           <Grid item xs={8}>
+            {/* Schema Name Input */}
             <Autocomplete
               fullWidth
               options={Object.keys(allDatatypeMaps[state.schemaType])}
@@ -178,6 +183,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
           </Grid>
         </Grid>
 
+        {/* Request Input */}
         <TextField
           margin="dense"
           size="small"
@@ -196,6 +202,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
         <Box my={1}>
           <Grid container spacing={1}>
             <Grid item xs={6}>
+              {/* Publish Once Button */}
               <Button
                 fullWidth
                 variant="contained"
@@ -212,6 +219,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
               </Button>
             </Grid>
             <Grid item xs={6}>
+              {/* Rate Publishing Toggle */}
               <Button
                 fullWidth
                 variant="contained"

--- a/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
+++ b/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
@@ -136,8 +136,18 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
               fullWidth
               options={Object.keys(allDatatypeMaps)}
               value={state.schemaType}
-              onChange={(_, newValue) => setState({ ...state, schemaType: newValue as keyof AllDatatypeMapsType })}
-              renderInput={(params) => <TextField {...params} label="Schema Type" margin="dense" size="small" />}
+              onChange={(_, newValue) =>
+                // Don't allow undefined since we need to use schema type as a key to get the schema names
+                setState({ ...state, schemaType: (newValue ?? state.schemaType) as keyof AllDatatypeMapsType })
+              }
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Schema Type"
+                  margin="dense"
+                  size="small"
+                />
+              )}
             />
           </Grid>
           <Grid item xs={8}>

--- a/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
+++ b/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
@@ -89,7 +89,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
       <Box m={1}>
         {(context.advertise == undefined || context.publish == undefined) && (
           <Alert variant="filled" severity="error">
-            Publishing topics is not supported by this connection
+            Publishing topics is not supported by this connection.
           </Alert>
         )}
 

--- a/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
+++ b/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
@@ -1,7 +1,7 @@
 import { AllDatatypeMapsType, allDatatypeMaps } from "@duke-robotics/defs/datatype_maps";
 import useTheme from "@duke-robotics/theme";
 import { Immutable, PanelExtensionContext, RenderState } from "@foxglove/studio";
-import { Box, Button, Grid, InputAdornment, MenuItem, TextField, ThemeProvider } from "@mui/material";
+import { Autocomplete, Box, Button, Grid, InputAdornment, MenuItem, TextField, ThemeProvider } from "@mui/material";
 import Alert from "@mui/material/Alert";
 import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -132,41 +132,22 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
 
         <Grid container spacing={1}>
           <Grid item xs={4}>
-            <TextField
-              select
-              label="Schema Type"
-              margin="dense"
-              size="small"
+            <Autocomplete
               fullWidth
+              options={Object.keys(allDatatypeMaps)}
               value={state.schemaType}
-              onChange={(event) => {
-                setState({ ...state, schemaType: event.target.value as "ros1" | "custom_msgs" });
-              }}
-            >
-              {Object.entries(allDatatypeMaps).map(([name, _]) => (
-                <MenuItem key={name} value={name}>
-                  {name}
-                </MenuItem>
-              ))}
-            </TextField>
+              onChange={(_, newValue) => setState({ ...state, schemaType: newValue as keyof AllDatatypeMapsType })}
+              renderInput={(params) => <TextField {...params} label="Schema Type" margin="dense" size="small" />}
+            />
           </Grid>
           <Grid item xs={8}>
-            <TextField
-              select
-              label="Schema Name"
-              margin="dense"
-              size="small"
+            <Autocomplete
               fullWidth
-              onChange={(event) => {
-                setState({ ...state, schemaName: event.target.value });
-              }}
-            >
-              {Object.entries(allDatatypeMaps[state.schemaType]).map(([name, _]) => (
-                <MenuItem key={name} value={name}>
-                  {name}
-                </MenuItem>
-              ))}
-            </TextField>
+              options={Object.keys(allDatatypeMaps[state.schemaType])}
+              value={state.schemaName}
+              onChange={(_, newValue) => setState({ ...state, schemaName: newValue ?? undefined })}
+              renderInput={(params) => <TextField {...params} label="Schema Name" margin="dense" size="small" />}
+            />
           </Grid>
         </Grid>
 

--- a/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
+++ b/foxglove/extensions/publish-topic-panel/src/PublishTopicPanel.tsx
@@ -21,7 +21,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
   const [renderDone, setRenderDone] = useState<(() => void) | undefined>();
   const [state, setState] = useState<PublishTopicPanelState>({
     topicName: "",
-    request: "{}",
+    request: "{\n\n}",
     schemaType: "ros1",
     publishRate: 10,
     repeatPublish: null,
@@ -87,26 +87,48 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
   return (
     <ThemeProvider theme={theme}>
       <Box m={1}>
-        {(context.advertise == undefined || context.publish == undefined) && (
-          <Alert variant="filled" severity="error">
-            Publishing topics is not supported by this connection.
-          </Alert>
-        )}
+        <Box my={1}>
+          {(context.advertise == undefined || context.publish == undefined) && (
+            <Alert variant="filled" severity="error">
+              Publishing topics is not supported by this connection.
+            </Alert>
+          )}
+        </Box>
 
-        <TextField
-          margin="dense"
-          size="small"
-          type="text"
-          label="Topic Name"
-          fullWidth
-          value={state.topicName}
-          onChange={(event) => {
-            setState({ ...state, topicName: event.target.value });
-          }}
-          InputProps={{
-            startAdornment: <InputAdornment position="start">/</InputAdornment>,
-          }}
-        />
+        <Grid container spacing={1}>
+          <Grid item xs={8}>
+            <TextField
+              margin="dense"
+              size="small"
+              type="text"
+              label="Topic Name"
+              fullWidth
+              value={state.topicName}
+              onChange={(event) => {
+                setState({ ...state, topicName: event.target.value });
+              }}
+              InputProps={{
+                startAdornment: <InputAdornment position="start">/</InputAdornment>,
+              }}
+            />
+          </Grid>
+          <Grid item xs={4}>
+            <TextField
+              margin="dense"
+              size="small"
+              error={state.invalidRate}
+              helperText={state.invalidRate ? "Rate must be positive." : ""}
+              label="Rate"
+              defaultValue={state.publishRate}
+              type="number"
+              fullWidth
+              onChange={handleRateChange}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">Hz</InputAdornment>,
+              }}
+            />
+          </Grid>
+        </Grid>
 
         <Grid container spacing={1}>
           <Grid item xs={4}>
@@ -151,20 +173,6 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
         <TextField
           margin="dense"
           size="small"
-          error={state.invalidRate}
-          helperText={state.invalidRate ? "Rate must be positive." : ""}
-          label="Rate (Hz)"
-          defaultValue={state.publishRate}
-          type="number"
-          fullWidth
-          onChange={handleRateChange}
-          InputProps={{
-            endAdornment: <InputAdornment position="end">Hz</InputAdornment>,
-          }}
-        />
-
-        <TextField
-          margin="dense"
           multiline
           label="Request"
           fullWidth
@@ -206,7 +214,7 @@ function PublishTopicPanel({ context }: { context: PanelExtensionContext }): JSX
                 onClick={toggleInterval}
                 color={state.repeatPublish == null ? "success" : "error"}
               >
-                {state.repeatPublish == null ? "Start Publish Loop" : "Stop Publish Loop"}
+                {state.repeatPublish == null ? "Start Publishing" : "Stop Publishing"}
               </Button>
             </Grid>
           </Grid>

--- a/foxglove/extensions/sensors-status-panel/src/SensorsStatusPanel.tsx
+++ b/foxglove/extensions/sensors-status-panel/src/SensorsStatusPanel.tsx
@@ -93,7 +93,7 @@ function SensorsStatusPanel({ context }: { context: PanelExtensionContext }): JS
       }
 
       if (renderState.currentFrame && renderState.currentFrame.length !== 0) {
-        const lastFrame = renderState.currentFrame[renderState.currentFrame.length - 1] as MessageEvent;
+        const lastFrame = renderState.currentFrame.at(-1) as MessageEvent;
         const sensorName = TOPICS_MAP_REVERSED[lastFrame.topic] as string;
 
         // Update sensorsTime to the current time and set connectStatus to true

--- a/foxglove/extensions/sensors-status-panel/src/SensorsStatusPanel.tsx
+++ b/foxglove/extensions/sensors-status-panel/src/SensorsStatusPanel.tsx
@@ -147,8 +147,8 @@ function SensorsStatusPanel({ context }: { context: PanelExtensionContext }): JS
                   key={sensor}
                   style={{
                     backgroundColor: state.connectStatus[sensor as topicsMapKeys]
-                      ? theme.palette.success.main
-                      : theme.palette.error.main,
+                      ? theme.palette.success.dark
+                      : theme.palette.error.dark,
                   }}
                 >
                   <TableCell>

--- a/foxglove/extensions/subscribe-topic-panel/src/SubscribeTopicPanel.tsx
+++ b/foxglove/extensions/subscribe-topic-panel/src/SubscribeTopicPanel.tsx
@@ -77,6 +77,7 @@ function SubscribeTopicPanel({ context }: { context: PanelExtensionContext }): J
               ...prevState,
               topic: newValue ?? undefined,
             }));
+            setState((oldState) => ({ ...oldState, message: undefined }));
           }}
           renderInput={(params) => <TextField {...params} label="Topic Name" margin="dense" size="small" />}
         />

--- a/foxglove/extensions/subscribe-topic-panel/src/SubscribeTopicPanel.tsx
+++ b/foxglove/extensions/subscribe-topic-panel/src/SubscribeTopicPanel.tsx
@@ -30,15 +30,10 @@ function SubscribeTopicPanel({ context }: { context: PanelExtensionContext }): J
     if (state.topic) {
       // Subscribe to the new image topic when a new topic is chosen.
       context.subscribe([{ topic: state.topic }]);
+    } else {
+      context.unsubscribeAll();
     }
   }, [context, state.topic]);
-
-  // Choose our first available image topic as a default once we have a list of topics available.
-  useEffect(() => {
-    if (state.topic == undefined) {
-      setState((oldState) => ({ ...oldState, topic: topics[0]?.name }));
-    }
-  }, [state.topic, topics]);
 
   // Setup our onRender function and start watching topics and currentFrame for messages.
   useEffect(() => {

--- a/foxglove/extensions/subscribe-topic-panel/src/SubscribeTopicPanel.tsx
+++ b/foxglove/extensions/subscribe-topic-panel/src/SubscribeTopicPanel.tsx
@@ -1,6 +1,6 @@
 import useTheme from "@duke-robotics/theme";
 import { PanelExtensionContext, RenderState, Topic, MessageEvent, Immutable } from "@foxglove/studio";
-import { Box, ThemeProvider } from "@mui/material";
+import { Autocomplete, Box, TextField, ThemeProvider } from "@mui/material";
 import { JsonViewer } from "@textea/json-viewer";
 import { useEffect, useState, useMemo } from "react";
 import { createRoot } from "react-dom/client";
@@ -52,7 +52,7 @@ function SubscribeTopicPanel({ context }: { context: PanelExtensionContext }): J
 
       // Save the most recent message on our topic.
       if (renderState.currentFrame && renderState.currentFrame.length > 0) {
-        const lastFrame = renderState.currentFrame[renderState.currentFrame.length - 1] as MessageEvent;
+        const lastFrame = renderState.currentFrame.at(-1) as MessageEvent;
 
         setState((oldState) => ({ ...oldState, message: lastFrame }));
       }
@@ -72,32 +72,28 @@ function SubscribeTopicPanel({ context }: { context: PanelExtensionContext }): J
   return (
     <ThemeProvider theme={theme}>
       <Box m={1}>
-        <div>
-          <label>Choose a topic to display: </label>
-          <select
-            value={state.topic}
-            onChange={(event) => {
-              setState((oldState) => ({ ...oldState, topic: event.target.value }));
-            }}
-            style={{ flex: 1 }}
-          >
-            {topics.map((topic) => (
-              <option key={topic.name} value={topic.name}>
-                {topic.name}
-              </option>
-            ))}
-          </select>
-
-          <JsonViewer
-            rootName={false}
-            value={state.message as object}
-            indentWidth={2}
-            theme={state.colorScheme}
-            enableClipboard={false}
-            displayDataTypes={false}
-            maxDisplayLength={10}
-          />
-        </div>
+        {/* Topic Name Input */}
+        <Autocomplete
+          fullWidth
+          options={topics.map((topic) => topic.name)}
+          value={state.topic}
+          onChange={(_, newValue) => {
+            setState((prevState) => ({
+              ...prevState,
+              topic: newValue ?? undefined,
+            }));
+          }}
+          renderInput={(params) => <TextField {...params} label="Topic Name" margin="dense" size="small" />}
+        />
+        {/* Message */}
+        <JsonViewer
+          rootName={false}
+          value={state.message}
+          indentWidth={2}
+          theme={state.colorScheme}
+          enableClipboard={true}
+          displayDataTypes={false}
+        />
       </Box>
     </ThemeProvider>
   );

--- a/foxglove/extensions/system-status-panel/src/SystemStatusPanel.tsx
+++ b/foxglove/extensions/system-status-panel/src/SystemStatusPanel.tsx
@@ -76,7 +76,7 @@ function SystemStatusPanel({ context }: { context: PanelExtensionContext }): JSX
                   key={row.statusName}
                   style={{
                     backgroundColor:
-                      row.value == undefined || row.value >= 90 ? theme.palette.error.main : theme.palette.success.main,
+                      row.value == undefined || row.value >= 90 ? theme.palette.error.dark : theme.palette.success.dark,
                   }}
                 >
                   <TableCell>

--- a/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
+++ b/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
@@ -2,7 +2,7 @@ import { allDatatypeMaps } from "@duke-robotics/defs/datatype_maps";
 import { CustomMsgsThrusterSpeeds } from "@duke-robotics/defs/types";
 import useTheme from "@duke-robotics/theme";
 import { PanelExtensionContext, RenderState, Immutable, MessageEvent } from "@foxglove/studio";
-import { TextField, Button, Alert, Tab, Tabs, CssBaseline } from "@mui/material";
+import { TextField, Button, Alert, Tab, Tabs, CssBaseline, Box } from "@mui/material";
 import Grid from "@mui/material/Unstable_Grid2";
 import { ThemeProvider } from "@mui/material/styles";
 import { useCallback, useEffect, useState, useRef } from "react";
@@ -264,14 +264,14 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <div style={{ padding: "5px" }}>
+      <Box m={1}>
         {/* SUBSCRIBING and PUBLISHING tabs */}
         <Tabs value={state.panelMode} onChange={handleModeChange} variant="fullWidth">
           <Tab label="Subscribing" value={PanelMode.SUBSCRIBING} />
           <Tab label="Publishing" value={PanelMode.PUBLISHING} />
         </Tabs>
         {/* Alert to be displayed if the panel is in PUBLISHING mode but cannot publish to THRUSTER_SPEEDS_TOPIC */}
-        <div style={{ padding: "5px" }}>
+        <Box my={1}>
           {state.panelMode === PanelMode.SUBSCRIBING ? (
             <></>
           ) : (
@@ -281,14 +281,15 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
               </Alert>
             )
           )}
-        </div>
-        <div>
+        </Box>
+        <Box>
           {/* Grid for displaying thruster speeds. If in SUBSCRIBING mode, displays subscribed speeds, otherwise
           displays TextFields for user to input thruster speeds values */}
           <Grid container rowSpacing={1} columnSpacing={0}>
             {thrusters.map((thruster) => (
               <Grid key={thruster} xs={6}>
                 <TextField
+                  type="number"
                   key={thruster}
                   id={thruster}
                   error={state.panelMode === PanelMode.PUBLISHING && !validateInput(state.tempThrusterSpeeds[thruster])}
@@ -308,8 +309,8 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
               </Grid>
             ))}
           </Grid>
-        </div>
-        <div style={{ display: "flex", justifyContent: "center", padding: "5px" }}>
+        </Box>
+        <Box my={1}>
           {state.panelMode === PanelMode.SUBSCRIBING ? (
             <></>
           ) : state.hasError ? (
@@ -338,8 +339,8 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
               {state.repeatPublish == null ? "Start Publishing" : "Stop Publishing"}
             </Button>
           )}
-        </div>
-      </div>
+        </Box>
+      </Box>
     </ThemeProvider>
   );
 }

--- a/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
+++ b/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
@@ -2,7 +2,6 @@ import { allDatatypeMaps } from "@duke-robotics/defs/datatype_maps";
 import { CustomMsgsThrusterSpeeds } from "@duke-robotics/defs/types";
 import useTheme from "@duke-robotics/theme";
 import { PanelExtensionContext, RenderState, Immutable, MessageEvent } from "@foxglove/studio";
-import { CheckCircleOutline, HighlightOff } from "@mui/icons-material";
 import { TextField, Button, Alert, Tab, Tabs, CssBaseline } from "@mui/material";
 import Grid from "@mui/material/Unstable_Grid2";
 import { ThemeProvider } from "@mui/material/styles";
@@ -321,9 +320,9 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
           ) : (
             // Button to start and stop publishing
             <Button
+              fullWidth
               variant="contained"
               color={state.repeatPublish == null ? "success" : "error"}
-              endIcon={state.repeatPublish == null ? <CheckCircleOutline /> : <HighlightOff />}
               onClick={
                 state.repeatPublish == null
                   ? () => {

--- a/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
+++ b/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
@@ -304,6 +304,7 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
                   InputProps={state.panelMode === PanelMode.SUBSCRIBING ? { readOnly: true } : {}}
                   defaultValue={state.panelMode === PanelMode.SUBSCRIBING ? false : 0}
                   onChange={updateTempSpeeds}
+                  fullWidth
                 />
               </Grid>
             ))}

--- a/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
+++ b/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
@@ -82,29 +82,38 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
   const [renderDone, setRenderDone] = useState<() => void | undefined>();
   const firstMount = useRef(true);
   const theme = useTheme();
-  const [state, setState] = useState<ThrusterSpeedsPanelState>({
-    // In the PUBLISHING mode, denotes whether all entered values in the panel are valid.
-    // If false, display an error warning which prevents the panel from publishing.
-    hasError: false,
-    panelMode: PanelMode.SUBSCRIBING,
-    // If publishing, holds the NodeJS.Timeout object used to publish messages at a constant rate, otherwise undefined
-    repeatPublish: null,
-    // Thruster speeds to be published
-    publisherThrusterSpeeds: { ...defaultThrusterSpeeds },
-    // Thruster speeds subscribed from the message
-    subscriberThrusterSpeeds: { ...defaultThrusterSpeeds },
-    // Holds temporary values of thruster speeds that the user entered before publishing
-    tempThrusterSpeeds: {
-      frontLeft: "",
-      frontRight: "",
-      backLeft: "",
-      backRight: "",
-      bottomFrontLeft: "",
-      bottomFrontRight: "",
-      bottomBackLeft: "",
-      bottomBackRight: "",
-    },
+  const [state, setState] = useState<ThrusterSpeedsPanelState>(() => {
+    const initialState = context.initialState as ThrusterSpeedsPanelState | undefined;
+
+    return {
+      // In the PUBLISHING mode, denotes whether all entered values in the panel are valid.
+      // If false, display an error warning which prevents the panel from publishing.
+      hasError: initialState?.hasError ?? false,
+      panelMode: initialState?.panelMode ?? PanelMode.SUBSCRIBING,
+      // If publishing, holds the NodeJS.Timeout object used to publish messages at a constant rate, otherwise undefined
+      repeatPublish: null,
+      // Thruster speeds to be published
+      publisherThrusterSpeeds: { ...defaultThrusterSpeeds },
+      // Thruster speeds subscribed from the message
+      subscriberThrusterSpeeds: { ...defaultThrusterSpeeds },
+      // Holds temporary values of thruster speeds that the user entered before publishing
+      tempThrusterSpeeds: initialState?.tempThrusterSpeeds ?? {
+        frontLeft: "",
+        frontRight: "",
+        backLeft: "",
+        backRight: "",
+        bottomFrontLeft: "",
+        bottomFrontRight: "",
+        bottomBackLeft: "",
+        bottomBackRight: "",
+      },
+    };
   });
+
+  // Save state upon change
+  useEffect(() => {
+    context.saveState(state);
+  }, [state, context]);
 
   useEffect(() => {
     renderDone?.();

--- a/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
+++ b/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
@@ -175,7 +175,7 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
 
     // Publishes the message to THRUSTER_SPEEDS_TOPIC
     try {
-      context.advertise(`/${THRUSTER_SPEEDS_TOPIC}`, THRUSTER_SPEEDS_MESSAGE_TYPE, {
+      context.advertise(THRUSTER_SPEEDS_TOPIC, THRUSTER_SPEEDS_MESSAGE_TYPE, {
         datatypes: allDatatypeMaps["custom_msgs"][THRUSTER_SPEEDS_MESSAGE_TYPE],
       });
       context.publish(`/${THRUSTER_SPEEDS_TOPIC}`, message);

--- a/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
+++ b/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
@@ -178,7 +178,7 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
       context.advertise(THRUSTER_SPEEDS_TOPIC, THRUSTER_SPEEDS_MESSAGE_TYPE, {
         datatypes: allDatatypeMaps["custom_msgs"][THRUSTER_SPEEDS_MESSAGE_TYPE],
       });
-      context.publish(`/${THRUSTER_SPEEDS_TOPIC}`, message);
+      context.publish(THRUSTER_SPEEDS_TOPIC, message);
 
       setState((oldState) => ({
         ...oldState,

--- a/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
+++ b/foxglove/extensions/thruster-speeds-panel/src/ThrusterSpeedsPanel.tsx
@@ -277,7 +277,7 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
           ) : (
             (context.advertise == undefined || context.publish == undefined) && (
               <Alert variant="filled" severity="error">
-                Publishing topics is not supported by this connection
+                Publishing topics is not supported by this connection.
               </Alert>
             )
           )}
@@ -315,7 +315,7 @@ function ThrusterSpeedsPanel({ context }: { context: PanelExtensionContext }): J
           ) : state.hasError ? (
             // Alert to be displayed if any user input thruster speeds are invalid
             <Alert variant="filled" severity="error">
-              The speed value for each thruster must be an integer between -128 and 127!
+              The speed value for each thruster must be an integer between -128 and 127.
             </Alert>
           ) : (
             // Button to start and stop publishing

--- a/foxglove/extensions/toggle-controls-panel/src/ToggleControlsPanel.tsx
+++ b/foxglove/extensions/toggle-controls-panel/src/ToggleControlsPanel.tsx
@@ -72,6 +72,7 @@ function ToggleControlsPanel({ context }: { context: PanelExtensionContext }): J
 
         {/* Toggle button */}
         <Button
+          fullWidth
           variant="contained"
           color={state.controlsEnabled ? "error" : "success"}
           onClick={toggleControls}

--- a/foxglove/extensions/toggle-controls-panel/src/ToggleControlsPanel.tsx
+++ b/foxglove/extensions/toggle-controls-panel/src/ToggleControlsPanel.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 import { createRoot } from "react-dom/client";
 
 // Define the service name for enabling/disabling controls
-const ENABLE_CONTROLS_SERVICE = "/enable_controls";
+const ENABLE_CONTROLS_SERVICE = "/controls/enable";
 
 type ToggleControlsPanel = {
   error?: Error | undefined; // Error object if service call fails

--- a/foxglove/extensions/toggle-controls-panel/src/ToggleControlsPanel.tsx
+++ b/foxglove/extensions/toggle-controls-panel/src/ToggleControlsPanel.tsx
@@ -59,7 +59,7 @@ function ToggleControlsPanel({ context }: { context: PanelExtensionContext }): J
           <Box mb={1}>
             {context.callService == undefined && (
               <Alert variant="filled" severity="error">
-                Calling services is not supported by this connection
+                Calling services is not supported by this connection.
               </Alert>
             )}
             {state.error != undefined && (

--- a/foxglove/extensions/toggle-joystick-panel/src/ToggleJoystickPanel.tsx
+++ b/foxglove/extensions/toggle-joystick-panel/src/ToggleJoystickPanel.tsx
@@ -303,7 +303,7 @@ function ToggleJoystickPanel({ context }: { context: PanelExtensionContext }): J
           <Box mb={1}>
             {context.callService == undefined && (
               <Alert variant="filled" severity="error">
-                Calling services is not supported by this connection
+                Calling services is not supported by this connection.
               </Alert>
             )}
             {state.error != undefined && (

--- a/foxglove/extensions/toggle-joystick-panel/src/ToggleJoystickPanel.tsx
+++ b/foxglove/extensions/toggle-joystick-panel/src/ToggleJoystickPanel.tsx
@@ -315,8 +315,9 @@ function ToggleJoystickPanel({ context }: { context: PanelExtensionContext }): J
         )}
 
         {/* Toggle button */}
-        <Box m={1}>
+        <Box my={1}>
           <Button
+            fullWidth
             variant="contained"
             color={state.joystickEnabled ? "error" : "success"}
             onClick={toggleJoystick}

--- a/foxglove/foxglove.py
+++ b/foxglove/foxglove.py
@@ -31,11 +31,12 @@ ORGANIZATION = "dukerobotics"
 if (SYSTEM := platform.system()) not in ("Linux", "Darwin", "Windows"):
     raise SystemExit(f"Unsupported platform: {SYSTEM}")
 
-LAYOUT_INSTALL_PATH = {
-    "Linux": pathlib.Path.home() / ".config/Foxglove Studio/studio-datastores/layouts-local/",
-    "Darwin": pathlib.Path.home() / "Library/Application Support/Foxglove Studio/studio-datastores/layouts-local/",
-    "Windows": pathlib.Path.home() / "AppData/Roaming/Foxglove Studio/studio-datastores/layouts-local/"
+STUDIO_DATASTORES_PATH = {
+    "Linux": pathlib.Path.home() / ".config/Foxglove Studio/studio-datastores/",
+    "Darwin": pathlib.Path.home() / "Library/Application Support/Foxglove Studio/studio-datastores/",
+    "Windows": pathlib.Path.home() / "AppData/Roaming/Foxglove Studio/studio-datastores/"
 }[SYSTEM]
+LAYOUT_INSTALL_PATH = STUDIO_DATASTORES_PATH / "layouts-local/"
 EXTENSION_INSTALL_PATH = pathlib.Path.home() / ".foxglove-studio/extensions/"
 
 FOXGLOVE_PATH = pathlib.Path(__file__).parent.resolve()
@@ -198,7 +199,7 @@ def uninstall_extensions(install_path: pathlib.Path = EXTENSION_INSTALL_PATH):
     print(f"Successfully uninstalled {len(extensions)} extension(s)\n")
 
 
-def uninstall_layouts(install_path: pathlib.Path = LAYOUT_INSTALL_PATH):
+def uninstall_layouts():
     """
     Uninstall all Duke Robotics layouts from Foxglove.
 
@@ -207,12 +208,18 @@ def uninstall_layouts(install_path: pathlib.Path = LAYOUT_INSTALL_PATH):
     Args:
         install_path: Path where layouts are installed.
     """
-    layouts = [d for d in install_path.iterdir() if d.name.startswith(ORGANIZATION)]
-    for layout in layouts:
-        layout.unlink()
-        print(f"{layout.name}: uninstalled")
+    remote_layouts = [d for d in STUDIO_DATASTORES_PATH.iterdir() if d.name.startswith("layouts-remote")]
 
-    print(f"Successfully uninstalled {len(layouts)} layouts(s)\n")
+    successes = 0
+    for path in (remote_layouts + [LAYOUT_INSTALL_PATH]):
+        layouts = [d for d in path.iterdir() if d.name.startswith(ORGANIZATION)]
+        for layout in layouts:
+            layout.unlink()
+            print(f"{layout.name}: uninstalled")
+
+            successes += 1
+
+    print(f"Successfully uninstalled {successes} layouts(s)\n")
 
 
 def extension_package(name: str, extension_paths: Sequence[pathlib.Path] = EXTENSION_PATHS):


### PR DESCRIPTION
Final GUI update to wrap up the Fall semester.

#### Foxglove.py
- Provide support for uninstalling layouts when signed in

#### Sensors Status Panel
- Use `.dark` color variant for background for consistency with MUI `Alert`

#### System Status Panel
- Use `.dark` color variant for background for consistency with MUI `Alert`

#### Publish Topic Panel
- Use MUI components
- Add publish rate mode (Closes #489)
- Use datatype maps to allow advertising of all custom message types
- Select schema name using autocomplete/selectors
- Save input fields across sessions

#### Call Service Panel
- Use MUI components
- Refactor call service function
- Save input fields across sessions

#### Subscribe Topic Panel
- Use MUI components

#### Thruster Speeds Panel
- Add `fullWidth` to `TextField`s
- Add `fullWidth` to `Button`
- Remove `endIcon` from `Button` (Our other toggle buttons do not have icons)

#### Toggle Controls Panel
- Add `fullWidth` to `Button`
- Change service to "controls/enable"

#### Toggle Joystick Panel
- Add `fullWidth` to `Button`