### PR TITLE
install gazebo and ros_gz package

### DIFF
--- a/docker/onboard/Dockerfile
+++ b/docker/onboard/Dockerfile
@@ -23,8 +23,17 @@ ENV TMP_PATH ${CUDA:+/usr/local/cuda/bin:}
 ENV PATH ${TMP_PATH}${PATH}
 ENV NVIDIA_VISIBLE_DEVICES ${CUDA:+all}
 ENV NVIDIA_DRIVER_CAPABILITIES ${CUDA:+all}
+ENV IGNITION_VERSION=citadel
 
 ### Basic Setup ###
+
+
+# Add gazebo ignition repo
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget lsb-release gnupg && \
+    sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" \
+    | sudo tee /etc/apt/28a0a75160794451c027b125a6edef1bf919d342
 
 # Update and install tools
 RUN apt-get update && \
@@ -46,10 +55,8 @@ RUN apt-get update && \
     python3-pandas \
     ros-noetic-foxglove-bridge \
     nmap \
-    libeigen3-dev &&\
-    apt-get clean && \
-    # Clear apt caches to reduce image size
-    rm -rf /var/lib/apt/lists/*
+    ignition-fortress \
+    libeigen3-dev
 
 # Get required python packages
 RUN pip3 install --no-cache-dir \
@@ -114,6 +121,17 @@ RUN git clone https://github.com/robotology/osqp-eigen.git && \
     cd ../.. && \
     rm -rf osqp-eigen
 
+# install ros-gz
+RUN mkdir -p ~/ros_ign_ws/src && \
+    cd ~/ros_ign_ws/src && \
+    git clone https://github.com/osrf/ros_ign.git -b noetic && \
+    cd ros_ign && \
+    git checkout 28a0a75160794451c027b125a6edef1bf919d342 && \
+    cd ~/ros_ign_ws && \
+    rosdep install -r --from-paths src -i -y --rosdistro noetic
+RUN cd ~/ros_ign_ws && \
+    /bin/bash -c "source /opt/ros/noetic/setup.bash && catkin_make install"
+
 # Install Arduino CLI for Arduino upload script
 # v0.17.0 is required due to issues with adding libraries in the current version v0.18.0
 RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=/usr/local/bin sh -s 0.17.0
@@ -125,6 +143,10 @@ RUN chmod +x /opt/ros/noetic/setup_network.bash
 # Set computer type
 ENV COMPUTER_TYPE=onboard
 RUN echo "COMPUTER_TYPE=onboard" >> /root/.ssh/environment
+
+RUN apt-get clean && \
+    # Clear apt caches to reduce image size
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory to codebase
 WORKDIR /root/dev/robosub-ros


### PR DESCRIPTION
This changes the dockerfile to install Igntion Gazebo Fortress (LTS) and the [ros_gz](https://github.com/gazebosim/ros_gz). These are necessary to get sim running. Involves adding source for ignition binary, cloning ros_gz source, installing rosdeps for ros_gz, and building the ros_gz_ws. Needed to move apt-get clean to end of dockerfile to avoid conflict with the rosdep install.