### PR TITLE
Remove Oogway Thruster PWM Offset

### DIFF
--- a/onboard/catkin_ws/src/offboard_comms/Arduino Sketchbooks/oogwayThrusterOffset.h
+++ b/onboard/catkin_ws/src/offboard_comms/Arduino Sketchbooks/oogwayThrusterOffset.h
@@ -1,4 +1,4 @@
 // PWM offset for oogway
 // Copied into the compile folder in the upload scripts depending on the ROBOT_NAME environment variable
 
-int THRUSTER_PWM_OFFSET = 31;
+int THRUSTER_PWM_OFFSET = 0;


### PR DESCRIPTION
New ESCs do not have a PWM offset.