### PR TITLE
Use git hash for foxglove package version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,5 +190,6 @@ jobs:
 
       - name: Build all Foxglove extensions
         run: |
+          pip install GitPython
           cd foxglove
           ./foxglove.py install -e

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,6 +14,7 @@ jobs:
 
       - name: Install Foxglove dependencies
         run: |
+          pip install GitPython
           cd foxglove
           ./foxglove.py build
 

--- a/foxglove/extensions/call-service-panel/package.json
+++ b/foxglove/extensions/call-service-panel/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "@duke-robotics/call-service-panel",
-  "displayName": "Call Service Panel",
-  "description": "Call ROS services",
-  "publisher": "Duke Robotics",
-  "version": "0.0.0",
-  "main": "./dist/extension.js",
-  "scripts": {
-    "build": "foxglove-extension build",
-    "foxglove:prepublish": "foxglove-extension build --mode production",
-    "lint:ci": "eslint --report-unused-disable-directives .",
-    "lint": "eslint --report-unused-disable-directives --fix .",
-    "local-install": "foxglove-extension install",
-    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-    "package": "foxglove-extension package",
-    "pretest": "foxglove-extension pretest"
-  },
-  "dependencies": {
-    "@textea/json-viewer": "^3.2.3"
-  }
+    "name": "@duke-robotics/call-service-panel",
+    "displayName": "Call Service Panel",
+    "description": "Call ROS services",
+    "publisher": "Duke Robotics",
+    "version": "1199586",
+    "main": "./dist/extension.js",
+    "scripts": {
+        "build": "foxglove-extension build",
+        "foxglove:prepublish": "foxglove-extension build --mode production",
+        "lint:ci": "eslint --report-unused-disable-directives .",
+        "lint": "eslint --report-unused-disable-directives --fix .",
+        "local-install": "foxglove-extension install",
+        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+        "package": "foxglove-extension package",
+        "pretest": "foxglove-extension pretest"
+    },
+    "dependencies": {
+        "@textea/json-viewer": "^3.2.3"
+    }
 }

--- a/foxglove/extensions/call-service-panel/package.json
+++ b/foxglove/extensions/call-service-panel/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@duke-robotics/call-service-panel",
-    "displayName": "Call Service Panel",
-    "description": "Call ROS services",
-    "publisher": "Duke Robotics",
-    "version": "1199586",
-    "main": "./dist/extension.js",
-    "scripts": {
-        "build": "foxglove-extension build",
-        "foxglove:prepublish": "foxglove-extension build --mode production",
-        "lint:ci": "eslint --report-unused-disable-directives .",
-        "lint": "eslint --report-unused-disable-directives --fix .",
-        "local-install": "foxglove-extension install",
-        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-        "package": "foxglove-extension package",
-        "pretest": "foxglove-extension pretest"
-    },
-    "dependencies": {
-        "@textea/json-viewer": "^3.2.3"
-    }
+  "name": "@duke-robotics/call-service-panel",
+  "displayName": "Call Service Panel",
+  "description": "Call ROS services",
+  "publisher": "Duke Robotics",
+  "version": "6c20219",
+  "main": "./dist/extension.js",
+  "scripts": {
+    "build": "foxglove-extension build",
+    "foxglove:prepublish": "foxglove-extension build --mode production",
+    "lint:ci": "eslint --report-unused-disable-directives .",
+    "lint": "eslint --report-unused-disable-directives --fix .",
+    "local-install": "foxglove-extension install",
+    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+    "package": "foxglove-extension package",
+    "pretest": "foxglove-extension pretest"
+  },
+  "dependencies": {
+    "@textea/json-viewer": "^3.2.3"
+  }
 }

--- a/foxglove/extensions/pid-panel/package.json
+++ b/foxglove/extensions/pid-panel/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@duke-robotics/pid-panel",
-    "displayName": "PID Panel",
-    "description": "Read/set PID gains",
-    "publisher": "Duke Robotics",
-    "version": "1199586",
-    "main": "./dist/extension.js",
-    "scripts": {
-        "build": "foxglove-extension build",
-        "foxglove:prepublish": "foxglove-extension build --mode production",
-        "lint:ci": "eslint --report-unused-disable-directives .",
-        "lint": "eslint --report-unused-disable-directives --fix .",
-        "local-install": "foxglove-extension install",
-        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-        "package": "foxglove-extension package",
-        "pretest": "foxglove-extension pretest"
-    },
-    "dependencies": {
-        "@textea/json-viewer": "^3.2.2"
-    }
+  "name": "@duke-robotics/pid-panel",
+  "displayName": "PID Panel",
+  "description": "Read/set PID gains",
+  "publisher": "Duke Robotics",
+  "version": "6c20219",
+  "main": "./dist/extension.js",
+  "scripts": {
+    "build": "foxglove-extension build",
+    "foxglove:prepublish": "foxglove-extension build --mode production",
+    "lint:ci": "eslint --report-unused-disable-directives .",
+    "lint": "eslint --report-unused-disable-directives --fix .",
+    "local-install": "foxglove-extension install",
+    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+    "package": "foxglove-extension package",
+    "pretest": "foxglove-extension pretest"
+  },
+  "dependencies": {
+    "@textea/json-viewer": "^3.2.2"
+  }
 }

--- a/foxglove/extensions/pid-panel/package.json
+++ b/foxglove/extensions/pid-panel/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "@duke-robotics/pid-panel",
-  "displayName": "PID Panel",
-  "description": "Read/set PID gains",
-  "publisher": "Duke Robotics",
-  "version": "0.0.0",
-  "main": "./dist/extension.js",
-  "scripts": {
-    "build": "foxglove-extension build",
-    "foxglove:prepublish": "foxglove-extension build --mode production",
-    "lint:ci": "eslint --report-unused-disable-directives .",
-    "lint": "eslint --report-unused-disable-directives --fix .",
-    "local-install": "foxglove-extension install",
-    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-    "package": "foxglove-extension package",
-    "pretest": "foxglove-extension pretest"
-  },
-  "dependencies": {
-    "@textea/json-viewer": "^3.2.2"
-  }
+    "name": "@duke-robotics/pid-panel",
+    "displayName": "PID Panel",
+    "description": "Read/set PID gains",
+    "publisher": "Duke Robotics",
+    "version": "1199586",
+    "main": "./dist/extension.js",
+    "scripts": {
+        "build": "foxglove-extension build",
+        "foxglove:prepublish": "foxglove-extension build --mode production",
+        "lint:ci": "eslint --report-unused-disable-directives .",
+        "lint": "eslint --report-unused-disable-directives --fix .",
+        "local-install": "foxglove-extension install",
+        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+        "package": "foxglove-extension package",
+        "pretest": "foxglove-extension pretest"
+    },
+    "dependencies": {
+        "@textea/json-viewer": "^3.2.2"
+    }
 }

--- a/foxglove/extensions/publish-topic-panel/package.json
+++ b/foxglove/extensions/publish-topic-panel/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@duke-robotics/publish-topic-panel",
-  "displayName": "Publish Topic Panel",
-  "description": "Publish ROS messages to a topic",
-  "publisher": "Duke Robotics",
-  "version": "0.0.0",
-  "main": "./dist/extension.js",
-  "scripts": {
-    "build": "foxglove-extension build",
-    "foxglove:prepublish": "foxglove-extension build --mode production",
-    "lint:ci": "eslint --report-unused-disable-directives .",
-    "lint": "eslint --report-unused-disable-directives --fix .",
-    "local-install": "foxglove-extension install",
-    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-    "package": "foxglove-extension package",
-    "pretest": "foxglove-extension pretest"
-  }
+    "name": "@duke-robotics/publish-topic-panel",
+    "displayName": "Publish Topic Panel",
+    "description": "Publish ROS messages to a topic",
+    "publisher": "Duke Robotics",
+    "version": "1199586",
+    "main": "./dist/extension.js",
+    "scripts": {
+        "build": "foxglove-extension build",
+        "foxglove:prepublish": "foxglove-extension build --mode production",
+        "lint:ci": "eslint --report-unused-disable-directives .",
+        "lint": "eslint --report-unused-disable-directives --fix .",
+        "local-install": "foxglove-extension install",
+        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+        "package": "foxglove-extension package",
+        "pretest": "foxglove-extension pretest"
+    }
 }

--- a/foxglove/extensions/publish-topic-panel/package.json
+++ b/foxglove/extensions/publish-topic-panel/package.json
@@ -1,18 +1,18 @@
 {
-    "name": "@duke-robotics/publish-topic-panel",
-    "displayName": "Publish Topic Panel",
-    "description": "Publish ROS messages to a topic",
-    "publisher": "Duke Robotics",
-    "version": "1199586",
-    "main": "./dist/extension.js",
-    "scripts": {
-        "build": "foxglove-extension build",
-        "foxglove:prepublish": "foxglove-extension build --mode production",
-        "lint:ci": "eslint --report-unused-disable-directives .",
-        "lint": "eslint --report-unused-disable-directives --fix .",
-        "local-install": "foxglove-extension install",
-        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-        "package": "foxglove-extension package",
-        "pretest": "foxglove-extension pretest"
-    }
+  "name": "@duke-robotics/publish-topic-panel",
+  "displayName": "Publish Topic Panel",
+  "description": "Publish ROS messages to a topic",
+  "publisher": "Duke Robotics",
+  "version": "6c20219",
+  "main": "./dist/extension.js",
+  "scripts": {
+    "build": "foxglove-extension build",
+    "foxglove:prepublish": "foxglove-extension build --mode production",
+    "lint:ci": "eslint --report-unused-disable-directives .",
+    "lint": "eslint --report-unused-disable-directives --fix .",
+    "local-install": "foxglove-extension install",
+    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+    "package": "foxglove-extension package",
+    "pretest": "foxglove-extension pretest"
+  }
 }

--- a/foxglove/extensions/sensors-status-panel/package.json
+++ b/foxglove/extensions/sensors-status-panel/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@duke-robotics/sensors-status-panel",
-  "displayName": "Sensors Status Panel",
-  "description": "Display the connected/disconnected status of sensors",
-  "publisher": "Duke Robotics",
-  "version": "0.0.0",
-  "main": "./dist/extension.js",
-  "scripts": {
-    "build": "foxglove-extension build",
-    "foxglove:prepublish": "foxglove-extension build --mode production",
-    "lint:ci": "eslint --report-unused-disable-directives .",
-    "lint": "eslint --report-unused-disable-directives --fix .",
-    "local-install": "foxglove-extension install",
-    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-    "package": "foxglove-extension package",
-    "pretest": "foxglove-extension pretest"
-  }
+    "name": "@duke-robotics/sensors-status-panel",
+    "displayName": "Sensors Status Panel",
+    "description": "Display the connected/disconnected status of sensors",
+    "publisher": "Duke Robotics",
+    "version": "1199586",
+    "main": "./dist/extension.js",
+    "scripts": {
+        "build": "foxglove-extension build",
+        "foxglove:prepublish": "foxglove-extension build --mode production",
+        "lint:ci": "eslint --report-unused-disable-directives .",
+        "lint": "eslint --report-unused-disable-directives --fix .",
+        "local-install": "foxglove-extension install",
+        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+        "package": "foxglove-extension package",
+        "pretest": "foxglove-extension pretest"
+    }
 }

--- a/foxglove/extensions/sensors-status-panel/package.json
+++ b/foxglove/extensions/sensors-status-panel/package.json
@@ -1,18 +1,18 @@
 {
-    "name": "@duke-robotics/sensors-status-panel",
-    "displayName": "Sensors Status Panel",
-    "description": "Display the connected/disconnected status of sensors",
-    "publisher": "Duke Robotics",
-    "version": "1199586",
-    "main": "./dist/extension.js",
-    "scripts": {
-        "build": "foxglove-extension build",
-        "foxglove:prepublish": "foxglove-extension build --mode production",
-        "lint:ci": "eslint --report-unused-disable-directives .",
-        "lint": "eslint --report-unused-disable-directives --fix .",
-        "local-install": "foxglove-extension install",
-        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-        "package": "foxglove-extension package",
-        "pretest": "foxglove-extension pretest"
-    }
+  "name": "@duke-robotics/sensors-status-panel",
+  "displayName": "Sensors Status Panel",
+  "description": "Display the connected/disconnected status of sensors",
+  "publisher": "Duke Robotics",
+  "version": "6c20219",
+  "main": "./dist/extension.js",
+  "scripts": {
+    "build": "foxglove-extension build",
+    "foxglove:prepublish": "foxglove-extension build --mode production",
+    "lint:ci": "eslint --report-unused-disable-directives .",
+    "lint": "eslint --report-unused-disable-directives --fix .",
+    "local-install": "foxglove-extension install",
+    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+    "package": "foxglove-extension package",
+    "pretest": "foxglove-extension pretest"
+  }
 }

--- a/foxglove/extensions/subscribe-topic-panel/package.json
+++ b/foxglove/extensions/subscribe-topic-panel/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "@duke-robotics/subscribe-topic-panel",
-  "displayName": "Subscribe Topic Panel",
-  "description": "Subscribe to ROS topics",
-  "publisher": "Duke Robotics",
-  "version": "0.0.0",
-  "main": "./dist/extension.js",
-  "scripts": {
-    "build": "foxglove-extension build",
-    "foxglove:prepublish": "foxglove-extension build --mode production",
-    "lint:ci": "eslint --report-unused-disable-directives .",
-    "lint": "eslint --report-unused-disable-directives --fix .",
-    "local-install": "foxglove-extension install",
-    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-    "package": "foxglove-extension package",
-    "pretest": "foxglove-extension pretest"
-  },
-  "dependencies": {
-    "@textea/json-viewer": "^3.2.3"
-  }
+    "name": "@duke-robotics/subscribe-topic-panel",
+    "displayName": "Subscribe Topic Panel",
+    "description": "Subscribe to ROS topics",
+    "publisher": "Duke Robotics",
+    "version": "1199586",
+    "main": "./dist/extension.js",
+    "scripts": {
+        "build": "foxglove-extension build",
+        "foxglove:prepublish": "foxglove-extension build --mode production",
+        "lint:ci": "eslint --report-unused-disable-directives .",
+        "lint": "eslint --report-unused-disable-directives --fix .",
+        "local-install": "foxglove-extension install",
+        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+        "package": "foxglove-extension package",
+        "pretest": "foxglove-extension pretest"
+    },
+    "dependencies": {
+        "@textea/json-viewer": "^3.2.3"
+    }
 }

--- a/foxglove/extensions/subscribe-topic-panel/package.json
+++ b/foxglove/extensions/subscribe-topic-panel/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@duke-robotics/subscribe-topic-panel",
-    "displayName": "Subscribe Topic Panel",
-    "description": "Subscribe to ROS topics",
-    "publisher": "Duke Robotics",
-    "version": "1199586",
-    "main": "./dist/extension.js",
-    "scripts": {
-        "build": "foxglove-extension build",
-        "foxglove:prepublish": "foxglove-extension build --mode production",
-        "lint:ci": "eslint --report-unused-disable-directives .",
-        "lint": "eslint --report-unused-disable-directives --fix .",
-        "local-install": "foxglove-extension install",
-        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-        "package": "foxglove-extension package",
-        "pretest": "foxglove-extension pretest"
-    },
-    "dependencies": {
-        "@textea/json-viewer": "^3.2.3"
-    }
+  "name": "@duke-robotics/subscribe-topic-panel",
+  "displayName": "Subscribe Topic Panel",
+  "description": "Subscribe to ROS topics",
+  "publisher": "Duke Robotics",
+  "version": "6c20219",
+  "main": "./dist/extension.js",
+  "scripts": {
+    "build": "foxglove-extension build",
+    "foxglove:prepublish": "foxglove-extension build --mode production",
+    "lint:ci": "eslint --report-unused-disable-directives .",
+    "lint": "eslint --report-unused-disable-directives --fix .",
+    "local-install": "foxglove-extension install",
+    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+    "package": "foxglove-extension package",
+    "pretest": "foxglove-extension pretest"
+  },
+  "dependencies": {
+    "@textea/json-viewer": "^3.2.3"
+  }
 }

--- a/foxglove/extensions/system-status-panel/package.json
+++ b/foxglove/extensions/system-status-panel/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@duke-robotics/system-status-panel",
-  "displayName": "System Status Panel",
-  "description": "Display the system usage of the onboard computer",
-  "publisher": "Duke Robotics",
-  "version": "0.0.0",
-  "main": "./dist/extension.js",
-  "scripts": {
-    "build": "foxglove-extension build",
-    "foxglove:prepublish": "foxglove-extension build --mode production",
-    "lint:ci": "eslint --report-unused-disable-directives .",
-    "lint": "eslint --report-unused-disable-directives --fix .",
-    "local-install": "foxglove-extension install",
-    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-    "package": "foxglove-extension package",
-    "pretest": "foxglove-extension pretest"
-  }
+    "name": "@duke-robotics/system-status-panel",
+    "displayName": "System Status Panel",
+    "description": "Display the system usage of the onboard computer",
+    "publisher": "Duke Robotics",
+    "version": "1199586",
+    "main": "./dist/extension.js",
+    "scripts": {
+        "build": "foxglove-extension build",
+        "foxglove:prepublish": "foxglove-extension build --mode production",
+        "lint:ci": "eslint --report-unused-disable-directives .",
+        "lint": "eslint --report-unused-disable-directives --fix .",
+        "local-install": "foxglove-extension install",
+        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+        "package": "foxglove-extension package",
+        "pretest": "foxglove-extension pretest"
+    }
 }

--- a/foxglove/extensions/system-status-panel/package.json
+++ b/foxglove/extensions/system-status-panel/package.json
@@ -1,18 +1,18 @@
 {
-    "name": "@duke-robotics/system-status-panel",
-    "displayName": "System Status Panel",
-    "description": "Display the system usage of the onboard computer",
-    "publisher": "Duke Robotics",
-    "version": "1199586",
-    "main": "./dist/extension.js",
-    "scripts": {
-        "build": "foxglove-extension build",
-        "foxglove:prepublish": "foxglove-extension build --mode production",
-        "lint:ci": "eslint --report-unused-disable-directives .",
-        "lint": "eslint --report-unused-disable-directives --fix .",
-        "local-install": "foxglove-extension install",
-        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-        "package": "foxglove-extension package",
-        "pretest": "foxglove-extension pretest"
-    }
+  "name": "@duke-robotics/system-status-panel",
+  "displayName": "System Status Panel",
+  "description": "Display the system usage of the onboard computer",
+  "publisher": "Duke Robotics",
+  "version": "6c20219",
+  "main": "./dist/extension.js",
+  "scripts": {
+    "build": "foxglove-extension build",
+    "foxglove:prepublish": "foxglove-extension build --mode production",
+    "lint:ci": "eslint --report-unused-disable-directives .",
+    "lint": "eslint --report-unused-disable-directives --fix .",
+    "local-install": "foxglove-extension install",
+    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+    "package": "foxglove-extension package",
+    "pretest": "foxglove-extension pretest"
+  }
 }

--- a/foxglove/extensions/thruster-allocs-panel/package.json
+++ b/foxglove/extensions/thruster-allocs-panel/package.json
@@ -1,27 +1,27 @@
 {
-    "name": "@duke-robotics/thruster-allocs-panel",
-    "displayName": "Thruster Allocs Panel",
-    "description": "Read/set thruster allocations",
-    "publisher": "Duke Robotics",
-    "version": "1199586",
-    "main": "./dist/extension.js",
-    "scripts": {
-        "build": "foxglove-extension build",
-        "build-deps": "npx ts-node src/thrusterConfigs.ts",
-        "foxglove:prepublish": "foxglove-extension build --mode production",
-        "lint:ci": "eslint --report-unused-disable-directives .",
-        "lint": "eslint --report-unused-disable-directives --fix .",
-        "local-install": "foxglove-extension install",
-        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-        "package": "foxglove-extension package",
-        "pretest": "foxglove-extension pretest"
-    },
-    "dependencies": {
-        "@foxglove/rosmsg-msgs-common": "^3.1.0",
-        "@mui/icons-material": "^5.14.12",
-        "@mui/material": "^5.14.12",
-        "fs": "^0.0.1-security",
-        "js-yaml": "^4.1.0",
-        "yarn": "^1.22.19"
-    }
+  "name": "@duke-robotics/thruster-allocs-panel",
+  "displayName": "Thruster Allocs Panel",
+  "description": "Read/set thruster allocations",
+  "publisher": "Duke Robotics",
+  "version": "6c20219",
+  "main": "./dist/extension.js",
+  "scripts": {
+    "build": "foxglove-extension build",
+    "build-deps": "npx ts-node src/thrusterConfigs.ts",
+    "foxglove:prepublish": "foxglove-extension build --mode production",
+    "lint:ci": "eslint --report-unused-disable-directives .",
+    "lint": "eslint --report-unused-disable-directives --fix .",
+    "local-install": "foxglove-extension install",
+    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+    "package": "foxglove-extension package",
+    "pretest": "foxglove-extension pretest"
+  },
+  "dependencies": {
+    "@foxglove/rosmsg-msgs-common": "^3.1.0",
+    "@mui/icons-material": "^5.14.12",
+    "@mui/material": "^5.14.12",
+    "fs": "^0.0.1-security",
+    "js-yaml": "^4.1.0",
+    "yarn": "^1.22.19"
+  }
 }

--- a/foxglove/extensions/thruster-allocs-panel/package.json
+++ b/foxglove/extensions/thruster-allocs-panel/package.json
@@ -1,27 +1,27 @@
 {
-  "name": "@duke-robotics/thruster-allocs-panel",
-  "displayName": "Thruster Allocs Panel",
-  "description": "Read/set thruster allocations",
-  "publisher": "Duke Robotics",
-  "version": "0.0.0",
-  "main": "./dist/extension.js",
-  "scripts": {
-    "build": "foxglove-extension build",
-    "build-deps": "npx ts-node src/thrusterConfigs.ts",
-    "foxglove:prepublish": "foxglove-extension build --mode production",
-    "lint:ci": "eslint --report-unused-disable-directives .",
-    "lint": "eslint --report-unused-disable-directives --fix .",
-    "local-install": "foxglove-extension install",
-    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-    "package": "foxglove-extension package",
-    "pretest": "foxglove-extension pretest"
-  },
-  "dependencies": {
-    "@foxglove/rosmsg-msgs-common": "^3.1.0",
-    "@mui/icons-material": "^5.14.12",
-    "@mui/material": "^5.14.12",
-    "fs": "^0.0.1-security",
-    "js-yaml": "^4.1.0",
-    "yarn": "^1.22.19"
-  }
+    "name": "@duke-robotics/thruster-allocs-panel",
+    "displayName": "Thruster Allocs Panel",
+    "description": "Read/set thruster allocations",
+    "publisher": "Duke Robotics",
+    "version": "1199586",
+    "main": "./dist/extension.js",
+    "scripts": {
+        "build": "foxglove-extension build",
+        "build-deps": "npx ts-node src/thrusterConfigs.ts",
+        "foxglove:prepublish": "foxglove-extension build --mode production",
+        "lint:ci": "eslint --report-unused-disable-directives .",
+        "lint": "eslint --report-unused-disable-directives --fix .",
+        "local-install": "foxglove-extension install",
+        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+        "package": "foxglove-extension package",
+        "pretest": "foxglove-extension pretest"
+    },
+    "dependencies": {
+        "@foxglove/rosmsg-msgs-common": "^3.1.0",
+        "@mui/icons-material": "^5.14.12",
+        "@mui/material": "^5.14.12",
+        "fs": "^0.0.1-security",
+        "js-yaml": "^4.1.0",
+        "yarn": "^1.22.19"
+    }
 }

--- a/foxglove/extensions/toggle-controls-panel/package.json
+++ b/foxglove/extensions/toggle-controls-panel/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@duke-robotics/toggle-controls-panel",
-    "displayName": "Toggle Controls Panel",
-    "description": "Toggle controls on/off",
-    "publisher": "Duke Robotics",
-    "version": "1199586",
-    "main": "./dist/extension.js",
-    "keywords": [],
-    "scripts": {
-        "build": "foxglove-extension build",
-        "foxglove:prepublish": "foxglove-extension build --mode production",
-        "lint:ci": "eslint --report-unused-disable-directives .",
-        "lint": "eslint --report-unused-disable-directives --fix .",
-        "local-install": "foxglove-extension install",
-        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-        "package": "foxglove-extension package",
-        "pretest": "foxglove-extension pretest"
-    }
+  "name": "@duke-robotics/toggle-controls-panel",
+  "displayName": "Toggle Controls Panel",
+  "description": "Toggle controls on/off",
+  "publisher": "Duke Robotics",
+  "version": "6c20219",
+  "main": "./dist/extension.js",
+  "keywords": [],
+  "scripts": {
+    "build": "foxglove-extension build",
+    "foxglove:prepublish": "foxglove-extension build --mode production",
+    "lint:ci": "eslint --report-unused-disable-directives .",
+    "lint": "eslint --report-unused-disable-directives --fix .",
+    "local-install": "foxglove-extension install",
+    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+    "package": "foxglove-extension package",
+    "pretest": "foxglove-extension pretest"
+  }
 }

--- a/foxglove/extensions/toggle-controls-panel/package.json
+++ b/foxglove/extensions/toggle-controls-panel/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "@duke-robotics/toggle-controls-panel",
-  "displayName": "Toggle Controls Panel",
-  "description": "Toggle controls on/off",
-  "publisher": "Duke Robotics",
-  "version": "0.0.0",
-  "main": "./dist/extension.js",
-  "keywords": [],
-  "scripts": {
-    "build": "foxglove-extension build",
-    "foxglove:prepublish": "foxglove-extension build --mode production",
-    "lint:ci": "eslint --report-unused-disable-directives .",
-    "lint": "eslint --report-unused-disable-directives --fix .",
-    "local-install": "foxglove-extension install",
-    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-    "package": "foxglove-extension package",
-    "pretest": "foxglove-extension pretest"
-  }
+    "name": "@duke-robotics/toggle-controls-panel",
+    "displayName": "Toggle Controls Panel",
+    "description": "Toggle controls on/off",
+    "publisher": "Duke Robotics",
+    "version": "1199586",
+    "main": "./dist/extension.js",
+    "keywords": [],
+    "scripts": {
+        "build": "foxglove-extension build",
+        "foxglove:prepublish": "foxglove-extension build --mode production",
+        "lint:ci": "eslint --report-unused-disable-directives .",
+        "lint": "eslint --report-unused-disable-directives --fix .",
+        "local-install": "foxglove-extension install",
+        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+        "package": "foxglove-extension package",
+        "pretest": "foxglove-extension pretest"
+    }
 }

--- a/foxglove/extensions/toggle-joystick-panel/package.json
+++ b/foxglove/extensions/toggle-joystick-panel/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@duke-robotics/toggle-joystick-panel",
-  "displayName": "Toggle Joystick Panel",
-  "description": "Toggle to publish joystick inputs as a desired power",
-  "publisher": "Duke Robotics",
-  "version": "0.0.0",
-  "main": "./dist/extension.js",
-  "scripts": {
-    "build": "foxglove-extension build",
-    "foxglove:prepublish": "foxglove-extension build --mode production",
-    "lint:ci": "eslint --report-unused-disable-directives .",
-    "lint": "eslint --report-unused-disable-directives --fix .",
-    "local-install": "foxglove-extension install",
-    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-    "package": "foxglove-extension package",
-    "pretest": "foxglove-extension pretest"
-  }
+    "name": "@duke-robotics/toggle-joystick-panel",
+    "displayName": "Toggle Joystick Panel",
+    "description": "Toggle to publish joystick inputs as a desired power",
+    "publisher": "Duke Robotics",
+    "version": "1199586",
+    "main": "./dist/extension.js",
+    "scripts": {
+        "build": "foxglove-extension build",
+        "foxglove:prepublish": "foxglove-extension build --mode production",
+        "lint:ci": "eslint --report-unused-disable-directives .",
+        "lint": "eslint --report-unused-disable-directives --fix .",
+        "local-install": "foxglove-extension install",
+        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+        "package": "foxglove-extension package",
+        "pretest": "foxglove-extension pretest"
+    }
 }

--- a/foxglove/extensions/toggle-joystick-panel/package.json
+++ b/foxglove/extensions/toggle-joystick-panel/package.json
@@ -1,18 +1,18 @@
 {
-    "name": "@duke-robotics/toggle-joystick-panel",
-    "displayName": "Toggle Joystick Panel",
-    "description": "Toggle to publish joystick inputs as a desired power",
-    "publisher": "Duke Robotics",
-    "version": "1199586",
-    "main": "./dist/extension.js",
-    "scripts": {
-        "build": "foxglove-extension build",
-        "foxglove:prepublish": "foxglove-extension build --mode production",
-        "lint:ci": "eslint --report-unused-disable-directives .",
-        "lint": "eslint --report-unused-disable-directives --fix .",
-        "local-install": "foxglove-extension install",
-        "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
-        "package": "foxglove-extension package",
-        "pretest": "foxglove-extension pretest"
-    }
+  "name": "@duke-robotics/toggle-joystick-panel",
+  "displayName": "Toggle Joystick Panel",
+  "description": "Toggle to publish joystick inputs as a desired power",
+  "publisher": "Duke Robotics",
+  "version": "6c20219",
+  "main": "./dist/extension.js",
+  "scripts": {
+    "build": "foxglove-extension build",
+    "foxglove:prepublish": "foxglove-extension build --mode production",
+    "lint:ci": "eslint --report-unused-disable-directives .",
+    "lint": "eslint --report-unused-disable-directives --fix .",
+    "local-install": "foxglove-extension install",
+    "watch:local-install": "nodemon --watch './src/**' -e ts,tsx --exec 'npm run local-install'",
+    "package": "foxglove-extension package",
+    "pretest": "foxglove-extension pretest"
+  }
 }

--- a/foxglove/foxglove.py
+++ b/foxglove/foxglove.py
@@ -190,7 +190,7 @@ def publish_extensions(extension_paths: Sequence[pathlib.Path], version: str = N
             package = json.load(file)
         package['version'] = version
         with open(extension / "package.json", 'w') as file:
-            json.dump(package, file, indent=4)
+            json.dump(package, file, indent=2)
 
         # Build extension package
         run_at_path("npm run package", extension)


### PR DESCRIPTION
A *unique* `version` must be specified in an extension's `package.json` to publish it.

 This PR adds a new `--version` (`-v`) flag to `foxglove.py` that sets the version used for publishing. If no version is specified, the short commit hash of HEAD is used.